### PR TITLE
ES6, Babel, Typescript definitions and Unit Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,18 @@ jobs:
       run: npm ci
     - name: Run ESLint
       run: npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Node.js 12.x
+      uses: actions/setup-node@v2.3.0
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Run Mocha
+      run: npm run test

--- a/conf-tsd.json
+++ b/conf-tsd.json
@@ -1,0 +1,11 @@
+{
+    "source": {
+        "include": ["src"]
+    },
+    "opts": {
+        "destination": "dist",
+        "outFile": "observer.d.ts",
+        "recurse": true,
+        "template": "node_modules/tsd-jsdoc/dist"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,203 @@
         "@babel/highlight": "^7.14.5"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
+      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
+      "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
@@ -22,6 +219,240 @@
         "@babel/types": "^7.15.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+      "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.0.tgz",
+      "integrity": "sha512-9KuleLT0e77wFUku6TUkqZzCEymBdtuQQ27MhEKzf9UOOJu3cYj98kyaDAzxpC7lV6DGiZFuC8XqDsq8/Kl6aQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
+      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz",
+      "integrity": "sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-member-expression-to-functions": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.0.tgz",
+      "integrity": "sha512-3DyG0zAFAZKcOp7aVr33ddwkxJ0Z0Jr5V99y3I690eYLpukJsJvAbzTy1ewoCqsML8SbIrjH14Jc/nSQ4TvNPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "regexpu-core": "^4.7.1"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz",
+      "integrity": "sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
+      "integrity": "sha512-Hk2SLxC9ZbcOhLpg/yMznzJ11W++lg5GMbxt1ev6TXUiJB0N42KPC+7w8a+eWGuqDnUYuwStJoZHM7RgmIOaGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -53,6 +484,446 @@
         "@babel/types": "^7.14.5"
       }
     },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
+      "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
+      "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "dev": true
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.0.tgz",
+      "integrity": "sha512-MLM1IOMe9aQBqMWxcRw8dcb9jlM86NIw7KA0Wri91Xkfied+dE0QuBFSBjMNvqzmS0OSIDsMNC24dBEkPUi7ew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-wrap-function": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
+      "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
@@ -67,6 +938,277 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
       "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.0.tgz",
+      "integrity": "sha512-VVMGzYY3vkWgCJML+qVLvGIam902mJW0FvT7Avj1zEe0Gn7D93aWdLblYARTxEw+6DhZmtzhBM2zv0ekE5zg1g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
+      "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -84,6 +1226,936 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
       "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
       "dev": true
+    },
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz",
+      "integrity": "sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.0.tgz",
+      "integrity": "sha512-4tcFwwicpWTrpl9qjf7UsoosaArgImF85AxqCRZlgc3IQDvkUHjJpruXAL58Wmj+T6fypWTC/BakfEkwIL/pwA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.0"
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz",
+      "integrity": "sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.16.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.0.tgz",
+      "integrity": "sha512-mCF3HcuZSY9Fcx56Lbn+CGdT44ioBMMvjNVldpKtj8tpniETdLjnxdHI1+sDWXIM1nNt+EanJOZ3IG9lzVjs7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-class-static-block": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.0.tgz",
+      "integrity": "sha512-mAy3sdcY9sKAkf3lQbDiv3olOfiLqI51c9DR9b19uMoR2Z6r5pmGl7dfNFqEvqOyqbf1ta4lknK4gc5PJn3mfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.0.tgz",
+      "integrity": "sha512-QGSA6ExWk95jFQgwz5GQ2Dr95cf7eI7TKutIXXTb7B1gCLTCz5hTjFTQGfLFBBiC5WSNi7udNwWsqbbMh1c4yQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.0.tgz",
+      "integrity": "sha512-CjI4nxM/D+5wCnhD11MHB1AwRSAYeDT+h8gCdcVJZ/OK7+wRzFsf7PFPWVpVpNRkHMmMkQWAHpTq+15IXQ1diA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.0.tgz",
+      "integrity": "sha512-kouIPuiv8mSi5JkEhzApg5Gn6hFyKPnlkO0a9YSzqRurH8wYzSlf6RJdzluAsbqecdW5pBvDJDfyDIUR/vLxvg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.0.tgz",
+      "integrity": "sha512-pbW0fE30sVTYXXm9lpVQQ/Vc+iTeQKiXlaNRZPPN2A2VdlWyAtsUrsQ3xydSlDW00TFMK7a8m3cDTkBF5WnV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.0.tgz",
+      "integrity": "sha512-3bnHA8CAFm7cG93v8loghDYyQ8r97Qydf63BeYiGgYbjKKB/XP53W15wfRC7dvKfoiJ34f6Rbyyx2btExc8XsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.0.tgz",
+      "integrity": "sha512-FAhE2I6mjispy+vwwd6xWPyEx3NYFS13pikDBWUAFGZvq6POGs5eNchw8+1CYoEgBl9n11I3NkzD7ghn25PQ9Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.0.tgz",
+      "integrity": "sha512-LU/+jp89efe5HuWJLmMmFG0+xbz+I2rSI7iLc1AlaeSMDMOGzWlc5yJrMN1d04osXN4sSfpo4O+azkBNBes0jg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.16.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.0.tgz",
+      "integrity": "sha512-kicDo0A/5J0nrsCPbn89mTG3Bm4XgYi0CZtvex9Oyw7gGZE3HXGD0zpQNH+mo+tEfbo8wbmMvJftOwpmPy7aVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.0.tgz",
+      "integrity": "sha512-Y4rFpkZODfHrVo70Uaj6cC1JJOt3Pp0MdWSwIKtb8z1/lsjl9AmnB7ErRFV+QNGIfcY1Eruc2UMx5KaRnXjMyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.0.tgz",
+      "integrity": "sha512-IvHmcTHDFztQGnn6aWq4t12QaBXTKr1whF/dgp9kz84X6GUcwq9utj7z2wFCUfeOup/QKnOlt2k0zxkGFx9ubg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.0.tgz",
+      "integrity": "sha512-3jQUr/HBbMVZmi72LpjQwlZ55i1queL8KcDTQEkAHihttJnAPrcvG9ZNXIfsd2ugpizZo595egYV6xy+pv4Ofw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-create-class-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.0.tgz",
+      "integrity": "sha512-ti7IdM54NXv29cA4+bNNKEMS4jLMCbJgl+Drv+FgYy0erJLAxNAIXcNjNjrRZEcWq0xJHsNVwQezskMFpF8N9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.0.tgz",
+      "integrity": "sha512-vIFb5250Rbh7roWARvCLvIJ/PtAU5Lhv7BtZ1u24COwpI9Ypjsh+bZcKk6rlIyalK+r0jOc1XQ8I4ovNxNrWrA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.0.tgz",
+      "integrity": "sha512-PbIr7G9kR8tdH6g8Wouir5uVjklETk91GMVSUq+VaOgiinbCkBP6Q7NN/suM/QutZkMJMvcyAriogcYAdhg8Gw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.0.tgz",
+      "integrity": "sha512-V14As3haUOP4ZWrLJ3VVx5rCnrYhMSHN/jX7z6FAt5hjRkLsb0snPCmJwSOML5oxkKO4FNoNv7V5hw/y2bjuvg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.0.tgz",
+      "integrity": "sha512-27n3l67/R3UrXfizlvHGuTwsRIFyce3D/6a37GRxn28iyTPvNXaW4XvznexRh1zUNLPjbLL22Id0XQElV94ruw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.0.tgz",
+      "integrity": "sha512-HUxMvy6GtAdd+GKBNYDWCIA776byUQH8zjnfjxwT1P1ARv/wFu8eBDpmXQcLS/IwRtrxIReGiplOwMeyO7nsDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.0.tgz",
+      "integrity": "sha512-63l1dRXday6S8V3WFY5mXJwcRAnPYxvFfTlt67bwV1rTyVTM5zrp0DBBb13Kl7+ehkCVwIZPumPpFP/4u70+Tw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.0.tgz",
+      "integrity": "sha512-Q7tBUwjxLTsHEoqktemHBMtb3NYwyJPTJdM+wDwb0g8PZ3kQUIzNvwD5lPaqW/p54TXBc/MXZu9Jr7tbUEUM8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.0.tgz",
+      "integrity": "sha512-FXlDZfQeLILfJlC6I1qyEwcHK5UpRCFkaoVyA1nk9A1L1Yu583YO4un2KsLBsu3IJb4CUbctZks8tD9xPQubLw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.0.tgz",
+      "integrity": "sha512-LIe2kcHKAZOJDNxujvmp6z3mfN6V9lJxubU4fJIGoQCkKe3Ec2OcbdlYP+vW++4MpxwG0d1wSDOJtQW5kLnkZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.0.tgz",
+      "integrity": "sha512-OwYEvzFI38hXklsrbNivzpO3fh87skzx8Pnqi4LoSYeav0xHlueSoCJrSgTPfnbyzopo5b3YVAJkFIcUpK2wsw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.0.tgz",
+      "integrity": "sha512-5QKUw2kO+GVmKr2wMYSATCTTnHyscl6sxFRAY+rvN7h7WB0lcG0o4NoV6ZQU32OZGVsYUsfLGgPQpDFdkfjlJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.0.tgz",
+      "integrity": "sha512-lBzMle9jcOXtSOXUpc7tvvTpENu/NuekNJVova5lCCWCV9/U1ho2HH2y0p6mBg8fPm/syEAbfaaemYGOHCY3mg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.0.tgz",
+      "integrity": "sha512-gQDlsSF1iv9RU04clgXqRjrPyyoJMTclFt3K1cjLmTKikc0s/6vE3hlDeEVC71wLTRu72Fq7650kABrdTc2wMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.0.tgz",
+      "integrity": "sha512-WRpw5HL4Jhnxw8QARzRvwojp9MIE7Tdk3ez6vRyUk1MwgjJN0aNpRoXainLR5SgxmoXx/vsXGZ6OthP6t/RbUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.0.tgz",
+      "integrity": "sha512-rWFhWbCJ9Wdmzln1NmSCqn7P0RAD+ogXG/bd9Kg5c7PKWkJtkiXmYsMBeXjDlzHpVTJ4I/hnjs45zX4dEv81xw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.0.tgz",
+      "integrity": "sha512-Dzi+NWqyEotgzk/sb7kgQPJQf7AJkQBWsVp1N6JWc1lBVo0vkElUnGdr1PzUBmfsCCN5OOFya3RtpeHk15oLKQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.16.0",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.0.tgz",
+      "integrity": "sha512-yuGBaHS3lF1m/5R+6fjIke64ii5luRUg97N2wr+z1sF0V+sNSXPxXDdEEL/iYLszsN5VKxVB1IPfEqhzVpiqvg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.0.tgz",
+      "integrity": "sha512-nx4f6no57himWiHhxDM5pjwhae5vLpTK2zCnDH8+wNLJy0TVER/LJRHl2bkt6w9Aad2sPD5iNNoUpY3X9sTGDg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.0.tgz",
+      "integrity": "sha512-LogN88uO+7EhxWc8WZuQ8vxdSyVGxhkh8WTC3tzlT8LccMuQdA81e9SGV6zY7kY2LjDhhDOFdQVxdGwPyBCnvg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.0.tgz",
+      "integrity": "sha512-fhjrDEYv2DBsGN/P6rlqakwRwIp7rBGLPbrKxwh7oVt5NNkIhZVOY2GRV+ULLsQri1bDqwDWnU3vhlmx5B2aCw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.0.tgz",
+      "integrity": "sha512-fds+puedQHn4cPLshoHcR1DTMN0q1V9ou0mUjm8whx9pGcNvDrVVrgw+KJzzCaiTdaYhldtrUps8DWVMgrSEyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.0.tgz",
+      "integrity": "sha512-XgnQEm1CevKROPx+udOi/8f8TiGhrUWiHiaUCIp47tE0tpFDjzXNTZc9E5CmCwxNjXTWEVqvRfWZYOTFvMa/ZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.0.tgz",
+      "integrity": "sha512-XLldD4V8+pOqX2hwfWhgwXzGdnDOThxaNTgqagOcpBgIxbUvpgU2FMvo5E1RyHbk756WYgdbS0T8y0Cj9FKkWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.0.tgz",
+      "integrity": "sha512-JAvGxgKuwS2PihiSFaDrp94XOzzTUeDeOQlcKzVAyaPap7BnZXK/lvMDiubkPTdotPKOIZq9xWXWnggUMYiExg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.0.tgz",
+      "integrity": "sha512-Dgs8NNCehHSvXdhEhln8u/TtJxfVwGYCgP2OOr5Z3Ar+B+zXicEOKNTyc+eca2cuEOMtjW6m9P9ijOt8QdqWkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.0.tgz",
+      "integrity": "sha512-iVb1mTcD8fuhSv3k99+5tlXu5N0v8/DPm2mO3WACLG6al1CGZH7v09HJyUb1TtYl/Z+KrM6pHSIJdZxP5A+xow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.0.tgz",
+      "integrity": "sha512-Ao4MSYRaLAQczZVp9/7E7QHsCuK92yHRrmVNRe/SlEJjhzivq0BSn8mEraimL8wizHZ3fuaHxKH0iwzI13GyGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.0.tgz",
+      "integrity": "sha512-/ntT2NljR9foobKk4E/YyOSwcGUXtYWv5tinMK/3RkypyNBNdhHUaq6Orw5DWq9ZcNlS03BIlEALFeQgeVAo4Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.0.tgz",
+      "integrity": "sha512-Rd4Ic89hA/f7xUSJQk5PnC+4so50vBoBfxjdQAdvngwidM8jYIBVxBZ/sARxD4e0yMXRbJVDrYf7dyRtIIKT6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.0.tgz",
+      "integrity": "sha512-++V2L8Bdf4vcaHi2raILnptTBjGEFxn5315YU+e8+EqXIucA+q349qWngCLpUYqqv233suJ6NOienIVUpS9cqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.0.tgz",
+      "integrity": "sha512-VFi4dhgJM7Bpk8lRc5CMaRGlKZ29W9C3geZjt9beuzSUrlJxsNwX7ReLwaL6WEvsOf2EQkyIJEPtF8EXjB/g2A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.0.tgz",
+      "integrity": "sha512-jHLK4LxhHjvCeZDWyA9c+P9XH1sOxRd1RO9xMtDVRAOND/PczPqizEtVdx4TQF/wyPaewqpT+tgQFYMnN/P94A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.0.tgz",
+      "integrity": "sha512-cdTu/W0IrviamtnZiTfixPfIncr2M1VqRrkjzZWlr1B4TVYimCFK5jkyOdP4qw2MrlKHi+b3ORj6x8GoCew8Dg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.0",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.0",
+        "@babel/plugin-proposal-class-static-block": "^7.16.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.16.0",
+        "@babel/plugin-proposal-export-namespace-from": "^7.16.0",
+        "@babel/plugin-proposal-json-strings": "^7.16.0",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.16.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.16.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.0",
+        "@babel/plugin-proposal-private-methods": "^7.16.0",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.16.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-transform-arrow-functions": "^7.16.0",
+        "@babel/plugin-transform-async-to-generator": "^7.16.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.16.0",
+        "@babel/plugin-transform-block-scoping": "^7.16.0",
+        "@babel/plugin-transform-classes": "^7.16.0",
+        "@babel/plugin-transform-computed-properties": "^7.16.0",
+        "@babel/plugin-transform-destructuring": "^7.16.0",
+        "@babel/plugin-transform-dotall-regex": "^7.16.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.16.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.16.0",
+        "@babel/plugin-transform-for-of": "^7.16.0",
+        "@babel/plugin-transform-function-name": "^7.16.0",
+        "@babel/plugin-transform-literals": "^7.16.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.16.0",
+        "@babel/plugin-transform-modules-amd": "^7.16.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.16.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.16.0",
+        "@babel/plugin-transform-modules-umd": "^7.16.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.0",
+        "@babel/plugin-transform-new-target": "^7.16.0",
+        "@babel/plugin-transform-object-super": "^7.16.0",
+        "@babel/plugin-transform-parameters": "^7.16.0",
+        "@babel/plugin-transform-property-literals": "^7.16.0",
+        "@babel/plugin-transform-regenerator": "^7.16.0",
+        "@babel/plugin-transform-reserved-words": "^7.16.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.16.0",
+        "@babel/plugin-transform-spread": "^7.16.0",
+        "@babel/plugin-transform-sticky-regex": "^7.16.0",
+        "@babel/plugin-transform-template-literals": "^7.16.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.16.0",
+        "@babel/plugin-transform-unicode-escapes": "^7.16.0",
+        "@babel/plugin-transform-unicode-regex": "^7.16.0",
+        "@babel/preset-modules": "^0.1.5",
+        "@babel/types": "^7.16.0",
+        "babel-plugin-polyfill-corejs2": "^0.2.3",
+        "babel-plugin-polyfill-corejs3": "^0.3.0",
+        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "core-js-compat": "^3.19.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+      "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
     },
     "@babel/template": {
       "version": "7.14.5",
@@ -198,6 +2270,33 @@
         "eslint-plugin-jsdoc": "^37.0.3"
       }
     },
+    "@rollup/plugin-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "acorn": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
@@ -252,18 +2351,51 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
+        "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz",
+      "integrity": "sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
+      "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "core-js-compat": "^3.18.0"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz",
+      "integrity": "sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.4"
       }
     },
     "balanced-match": {
@@ -282,10 +2414,39 @@
         "concat-map": "0.0.1"
       }
     },
+    "browserslist": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
+      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001274",
+        "electron-to-chromium": "^1.3.886",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001278",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
+      "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
       "dev": true
     },
     "chalk": {
@@ -326,6 +2487,33 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "core-js-compat": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.19.1.tgz",
+      "integrity": "sha512-Q/VJ7jAF/y68+aUsQJ/afPOewdsGkDtcMb40J8MbuWKlK3Y+wtHq8bTHKPj2WKWLIqmS5JhHs4CzHtz6pT2W6g==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.17.6",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -352,6 +2540,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -361,6 +2558,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.889",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.889.tgz",
+      "integrity": "sha512-suEUoPTD1mExjL9TdmH7cvEiWJVM2oEiAi+Y1p0QKxI2HcRlT44qDTP2c1aZmVwRemIPYOpxmV7CxQCOWcm4XQ==",
+      "dev": true
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -369,6 +2572,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -538,12 +2747,6 @@
         }
       }
     },
-    "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true
-    },
     "espree": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
@@ -591,6 +2794,12 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -667,6 +2876,23 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -709,6 +2935,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "ignore": {
@@ -826,6 +3058,15 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -840,6 +3081,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.merge": {
@@ -866,6 +3113,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -877,6 +3130,30 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -928,6 +3205,18 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -946,17 +3235,84 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+      "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "regexpu-core": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
+      "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^9.0.0",
+        "regjsgen": "^0.5.2",
+        "regjsparser": "^0.7.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.0.0"
+      }
+    },
     "regextras": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
       "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
       "dev": true
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
+      "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
     },
     "resolve": {
       "version": "1.20.0",
@@ -991,6 +3347,12 @@
       "requires": {
         "fsevents": "~2.3.2"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.5",
@@ -1099,6 +3461,34 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
       "dev": true
     },
     "uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,6 +2432,12 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2491,6 +2497,15 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
       "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
       "dev": true
+    },
+    "catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
     },
     "chai": {
       "version": "4.3.4",
@@ -2700,6 +2715,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -3077,6 +3098,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -3234,6 +3261,45 @@
         }
       }
     },
+    "js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "jsdoc": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.9.4",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.1",
+        "klaw": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "markdown-it-anchor": "^5.2.7",
+        "marked": "^2.0.3",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.13.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
     "jsdoc-type-pratt-parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
@@ -3267,6 +3333,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3275,6 +3350,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "lodash": {
@@ -3365,6 +3449,37 @@
         "yallist": "^4.0.0"
       }
     },
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "dev": true
+    },
+    "marked": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3378,6 +3493,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
     "mocha": {
@@ -3741,6 +3862,15 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -3883,6 +4013,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3904,6 +4040,23 @@
         "is-number": "^7.0.0"
       }
     },
+    "tsd-jsdoc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tsd-jsdoc/-/tsd-jsdoc-2.5.0.tgz",
+      "integrity": "sha512-80fcJLAiUeerg4xPftp+iEEKWUjJjHk9AvcHwJqA8Zw0R4oASdu3kT/plE/Zj19QUTz8KupyOX25zStlNJjS9g==",
+      "dev": true,
+      "requires": {
+        "typescript": "^3.2.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
+        }
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3923,6 +4076,24 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -4030,6 +4201,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2297,6 +2297,12 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
@@ -2342,6 +2348,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2350,6 +2366,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -2404,6 +2426,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2413,6 +2441,21 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "browserslist": {
       "version": "4.17.6",
@@ -2449,6 +2492,20 @@
       "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
       "dev": true
     },
+    "chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2458,6 +2515,50 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "color-convert": {
@@ -2534,6 +2635,21 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2549,6 +2665,12 @@
         "object-keys": "^1.0.12"
       }
     },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2562,6 +2684,12 @@
       "version": "1.3.889",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.889.tgz",
       "integrity": "sha512-suEUoPTD1mExjL9TdmH7cvEiWJVM2oEiAi+Y1p0QKxI2HcRlT44qDTP2c1aZmVwRemIPYOpxmV7CxQCOWcm4XQ==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "enquirer": {
@@ -2835,6 +2963,21 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2882,6 +3025,18 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -2922,6 +3077,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2941,6 +3102,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "ignore": {
@@ -2981,6 +3148,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
@@ -2996,6 +3172,12 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3004,6 +3186,24 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -3095,6 +3295,67 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3119,10 +3380,134 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mocha": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
+      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.2",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.7",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.25",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.1.5",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "natural-compare": {
@@ -3135,6 +3520,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "object-keys": {
@@ -3187,6 +3578,12 @@
         "callsites": "^3.0.0"
       }
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3203,6 +3600,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picocolors": {
@@ -3234,6 +3637,24 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "regenerate": {
       "version": "1.4.2",
@@ -3314,6 +3735,12 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -3361,6 +3788,15 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "shebang-command": {
@@ -3412,6 +3848,17 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3448,6 +3895,15 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3456,6 +3912,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",
@@ -3521,16 +3983,112 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        }
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "main": "index.js",
   "module": "index.mjs",
+  "types": "observer.d.ts",
   "type": "module",
   "bugs": {
     "url": "https://github.com/playcanvas/playcanvas-observer/issues"
@@ -34,15 +35,19 @@
     "@rollup/plugin-babel": "5.3.0",
     "chai": "4.3.4",
     "eslint": "^8.1.0",
+    "jsdoc": "^3.6.7",
     "mocha": "^9.1.3",
-    "rollup": "^2.59.0"
+    "rollup": "^2.59.0",
+    "tsd-jsdoc": "2.5.0",
+    "typescript": "^4.4.4"
   },
   "scripts": {
     "build:umd": "rollup -c --environment target:umd",
     "build:es6": "rollup -c --environment target:es6",
     "build": "rollup -c --environment target:all",
     "lint": "eslint --ext .js index.js src rollup.config.js",
-    "publish:observer": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist",
-    "test": "mocha"
+    "publish:observer": "npm run build && npm run tsd && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist",
+    "test": "mocha",
+    "tsd": "jsdoc -c conf-tsd.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "main": "index.js",
   "module": "index.mjs",
+  "type": "module",
   "bugs": {
     "url": "https://github.com/playcanvas/playcanvas-observer/issues"
   },
@@ -31,7 +32,9 @@
     "@babel/preset-env": "^7.16.0",
     "@playcanvas/eslint-config": "^1.0.13",
     "@rollup/plugin-babel": "5.3.0",
+    "chai": "4.3.4",
     "eslint": "^8.1.0",
+    "mocha": "^9.1.3",
     "rollup": "^2.59.0"
   },
   "scripts": {
@@ -39,6 +42,7 @@
     "build:es6": "rollup -c --environment target:es6",
     "build": "rollup -c --environment target:all",
     "lint": "eslint --ext .js index.js src rollup.config.js",
-    "publish:observer": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist"
+    "publish:observer": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist",
+    "test": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "module": "index.mjs",
   "eslintConfig": {
-    "extends": "@playcanvas/eslint-config"
+    "extends": "@playcanvas/eslint-config",
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+      "requireConfigFile": false
+    }
   },
   "scripts": {
     "build:umd": "rollup -c --environment target:umd",
@@ -25,8 +29,11 @@
   },
   "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
   "devDependencies": {
+    "@babel/core": "^7.16.0",
+    "@babel/eslint-parser": "^7.16.0",
+    "@babel/preset-env": "^7.16.0",
     "@playcanvas/eslint-config": "^1.0.13",
-    "babel-eslint": "^10.1.0",
+    "@rollup/plugin-babel": "5.3.0",
     "eslint": "^8.1.0",
     "rollup": "^2.59.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,23 @@
 {
   "name": "@playcanvas/observer",
   "version": "1.1.0",
-  "description": "Contains the Observer class and related functionality used across the PlayCanvas Editor, pcui etc.",
+  "author": "PlayCanvas <support@playcanvas.com>",
+  "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
+  "description": "Generic implementation of the observer pattern",
+  "keywords": [
+    "playcanvas",
+    "observer"
+  ],
+  "license": "MIT",
   "main": "index.js",
   "module": "index.mjs",
+  "bugs": {
+    "url": "https://github.com/playcanvas/playcanvas-observer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/playcanvas/playcanvas-observer.git"
+  },
   "eslintConfig": {
     "extends": "@playcanvas/eslint-config",
     "parser": "@babel/eslint-parser",
@@ -11,23 +25,6 @@
       "requireConfigFile": false
     }
   },
-  "scripts": {
-    "build:umd": "rollup -c --environment target:umd",
-    "build:es6": "rollup -c --environment target:es6",
-    "build": "rollup -c --environment target:all",
-    "lint": "eslint --ext .js index.js src rollup.config.js",
-    "publish:observer": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/playcanvas/playcanvas-observer.git"
-  },
-  "author": "PlayCanvas <support@playcanvas.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/playcanvas/playcanvas-observer/issues"
-  },
-  "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.0",
@@ -36,5 +33,12 @@
     "@rollup/plugin-babel": "5.3.0",
     "eslint": "^8.1.0",
     "rollup": "^2.59.0"
+  },
+  "scripts": {
+    "build:umd": "rollup -c --environment target:umd",
+    "build:es6": "rollup -c --environment target:es6",
+    "build": "rollup -c --environment target:all",
+    "lint": "eslint --ext .js index.js src rollup.config.js",
+    "publish:observer": "npm run build && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,54 @@
+import babel from '@rollup/plugin-babel';
+
+const es5Options = {
+    babelHelpers: 'bundled',
+    babelrc: false,
+    comments: false,
+    compact: false,
+    minified: false,
+    presets: [
+        [
+            '@babel/preset-env', {
+                loose: true,
+                modules: false,
+                targets: {
+                    ie: "11"
+                }
+            }
+        ]
+    ]
+};
+
+const moduleOptions = {
+    babelHelpers: 'bundled',
+    babelrc: false,
+    comments: false,
+    compact: false,
+    minified: false,
+    presets: [
+        [
+            '@babel/preset-env', {
+                bugfixes: true,
+                loose: true,
+                modules: false,
+                targets: {
+                    esmodules: true
+                }
+            }
+        ]
+    ]
+};
+
 const umd = {
     input: 'index.js',
     output: {
         file: 'dist/index.js',
         format: 'umd',
         name: 'observer'
-    }
+    },
+    plugins: [
+        babel(es5Options)
+    ]
 };
 
 const es6 = {
@@ -12,7 +56,10 @@ const es6 = {
     output: {
         file: 'dist/index.mjs',
         format: 'module'
-    }
+    },
+    plugins: [
+        babel(moduleOptions)
+    ]
 };
 
 let targets;

--- a/src/event-handle.js
+++ b/src/event-handle.js
@@ -1,0 +1,50 @@
+/**
+ * @class
+ * @name EventHandle
+ * @param {Events} owner - Owner
+ * @param {string} name - Name
+ * @param {HandleEvent} fn - Callback function
+ */
+class EventHandle {
+    constructor(owner, name, fn) {
+        this.owner = owner;
+        this.name = name;
+        this.fn = fn;
+    }
+
+    /**
+     * @name EventHandle#unbind
+     */
+    unbind() {
+        if (! this.owner)
+            return;
+
+        this.owner.unbind(this.name, this.fn);
+
+        this.owner = null;
+        this.name = null;
+        this.fn = null;
+    }
+
+    /**
+     * @name EventHandle#call
+     */
+    call() {
+        if (! this.fn)
+            return;
+
+        this.fn.call(this.owner, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6], arguments[7]);
+    }
+
+    /**
+     * @name EventHandle#on
+     * @param {string} name - Name
+     * @param {HandleEvent} fn - Callback function
+     * @returns {EventHandle} - EventHandle
+     */
+    on(name, fn) {
+        return this.owner.on(name, fn);
+    }
+}
+
+export default EventHandle;

--- a/src/event-handle.js
+++ b/src/event-handle.js
@@ -16,7 +16,7 @@ class EventHandle {
      * @name EventHandle#unbind
      */
     unbind() {
-        if (! this.owner)
+        if (!this.owner)
             return;
 
         this.owner.unbind(this.name, this.fn);
@@ -30,7 +30,7 @@ class EventHandle {
      * @name EventHandle#call
      */
     call() {
-        if (! this.fn)
+        if (!this.fn)
             return;
 
         this.fn.call(this.owner, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6], arguments[7]);

--- a/src/event-handle.js
+++ b/src/event-handle.js
@@ -1,11 +1,9 @@
-/**
- * @class
- * @name EventHandle
- * @param {Events} owner - Owner
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- */
 class EventHandle {
+    /**
+     * @param {Events} owner - Owner
+     * @param {string} name - Name
+     * @param {HandleEvent} fn - Callback function
+     */
     constructor(owner, name, fn) {
         this.owner = owner;
         this.name = name;
@@ -13,7 +11,6 @@ class EventHandle {
     }
 
     /**
-     * @name EventHandle#unbind
      */
     unbind() {
         if (!this.owner)
@@ -27,7 +24,6 @@ class EventHandle {
     }
 
     /**
-     * @name EventHandle#call
      */
     call() {
         if (!this.fn)
@@ -37,7 +33,6 @@ class EventHandle {
     }
 
     /**
-     * @name EventHandle#on
      * @param {string} name - Name
      * @param {HandleEvent} fn - Callback function
      * @returns {EventHandle} - EventHandle

--- a/src/events.js
+++ b/src/events.js
@@ -1,3 +1,5 @@
+import EventHandle from './event-handle.js';
+
 /**
  * @callback HandleEvent
  * @description Callback used by {@link Events} and {@link EventHandle} functions. Note the callback is limited to 8 arguments.
@@ -15,207 +17,161 @@
  * @class
  * @name Events
  */
-function Events() {
-    // _world
-    Object.defineProperty(
-        this,
-        '_events', {
-            enumerable: false,
-            configurable: false,
-            writable: true,
-            value: { }
-        }
-    );
-
-    this._suspendEvents = false;
-
-    this._additionalEmitters = [];
-
-    Object.defineProperty(this, 'suspendEvents', {
-        get: function () {
-            return this._suspendEvents;
-        },
-        set: function (value) {
-            this._suspendEvents = !!value;
-        }
-    });
-}
-
-/**
- * @name Events#on
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- * @returns {EventHandle} EventHandle
- */
-Events.prototype.on = function (name, fn) {
-    var events = this._events[name];
-    if (events === undefined) {
-        this._events[name] = [fn];
-    } else {
-        if (events.indexOf(fn) === -1)
-            events.push(fn);
-    }
-    return new EventHandle(this, name, fn);
-};
-
-/**
- * @name Events#once
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- * @returns {EventHandle} EventHandle
- */
-Events.prototype.once = function (name, fn) {
-    var self = this;
-    var evt = this.on(name, function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
-        fn.call(self, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-        evt.unbind();
-    });
-    return evt;
-};
-
-/**
- * @name Events#emit
- * @param {string} name - Name
- * @param {any} arg0 - First argument
- * @param {any} arg1 - Second argument
- * @param {any} arg2 - Third argument
- * @param {any} arg3 - Fourth argument
- * @param {any} arg4 - Fifth argument
- * @param {any} arg5 - Sixth argument
- * @param {any} arg6 - Seventh argument
- * @param {any} arg7 - Eights argument
- * @returns {Events} Self for chaining.
- */
-Events.prototype.emit = function (name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
-    if (this._suspendEvents) return;
-
-    var events = this._events[name];
-    if (events && events.length) {
-        events = events.slice(0);
-
-        for (var i = 0; i < events.length; i++) {
-            if (! events[i])
-                continue;
-
-            try {
-                events[i].call(this, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-            } catch (ex) {
-                console.info('%c%s %c(event error)', 'color: #06f', name, 'color: #f00');
-                console.log(ex.stack);
+class Events {
+    constructor() {
+        // _world
+        Object.defineProperty(
+            this,
+            '_events', {
+                enumerable: false,
+                configurable: false,
+                writable: true,
+                value: { }
             }
-        }
+        );
+
+        this._suspendEvents = false;
+
+        this._additionalEmitters = [];
     }
 
-    if (this._additionalEmitters.length) {
-        const emitters = this._additionalEmitters.slice();
-        emitters.forEach((emitter) => {
-            emitter.emit(name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-        });
+    get suspendEvents() {
+        return this._suspendEvents;
     }
 
-    return this;
-};
+    set suspendEvents(value) {
+        this._suspendEvents = !!value;
+    }
 
-/**
- * @name Events#unbind
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- * @returns {Events} - This
- */
-Events.prototype.unbind = function (name, fn) {
-    if (name) {
+    /**
+     * @name Events#on
+     * @param {string} name - Name
+     * @param {HandleEvent} fn - Callback function
+     * @returns {EventHandle} EventHandle
+     */
+    on(name, fn) {
         var events = this._events[name];
-        if (! events)
-            return this;
+        if (events === undefined) {
+            this._events[name] = [fn];
+        } else {
+            if (events.indexOf(fn) === -1)
+                events.push(fn);
+        }
+        return new EventHandle(this, name, fn);
+    }
 
-        if (fn) {
-            var i = events.indexOf(fn);
-            if (i !== -1) {
-                if (events.length === 1) {
-                    delete this._events[name];
-                } else {
-                    events.splice(i, 1);
+    /**
+     * @name Events#once
+     * @param {string} name - Name
+     * @param {HandleEvent} fn - Callback function
+     * @returns {EventHandle} EventHandle
+     */
+    once(name, fn) {
+        var self = this;
+        var evt = this.on(name, function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
+            fn.call(self, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            evt.unbind();
+        });
+        return evt;
+    }
+
+    /**
+     * @name Events#emit
+     * @param {string} name - Name
+     * @param {any} arg0 - First argument
+     * @param {any} arg1 - Second argument
+     * @param {any} arg2 - Third argument
+     * @param {any} arg3 - Fourth argument
+     * @param {any} arg4 - Fifth argument
+     * @param {any} arg5 - Sixth argument
+     * @param {any} arg6 - Seventh argument
+     * @param {any} arg7 - Eights argument
+     * @returns {Events} Self for chaining.
+     */
+    emit(name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
+        if (this._suspendEvents) return;
+
+        var events = this._events[name];
+        if (events && events.length) {
+            events = events.slice(0);
+
+            for (var i = 0; i < events.length; i++) {
+                if (! events[i])
+                    continue;
+
+                try {
+                    events[i].call(this, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                } catch (ex) {
+                    console.info('%c%s %c(event error)', 'color: #06f', name, 'color: #f00');
+                    console.log(ex.stack);
                 }
             }
-        } else {
-            delete this._events[name];
         }
-    } else {
-        this._events = { };
+
+        if (this._additionalEmitters.length) {
+            const emitters = this._additionalEmitters.slice();
+            emitters.forEach((emitter) => {
+                emitter.emit(name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            });
+        }
+
+        return this;
     }
 
-    return this;
-};
+    /**
+     * @name Events#unbind
+     * @param {string} name - Name
+     * @param {HandleEvent} fn - Callback function
+     * @returns {Events} - This
+     */
+    unbind(name, fn) {
+        if (name) {
+            var events = this._events[name];
+            if (! events)
+                return this;
 
-/**
- * Adds another emitter. Any events fired by this instance
- * will also be fired on the additional emitter.
- *
- * @param {Events} emitter - The emitter
- */
-Events.prototype.addEmitter = function (emitter) {
-    if (!this._additionalEmitters.includes(emitter)) {
-        this._additionalEmitters.push(emitter);
+            if (fn) {
+                var i = events.indexOf(fn);
+                if (i !== -1) {
+                    if (events.length === 1) {
+                        delete this._events[name];
+                    } else {
+                        events.splice(i, 1);
+                    }
+                }
+            } else {
+                delete this._events[name];
+            }
+        } else {
+            this._events = { };
+        }
+
+        return this;
     }
-};
 
-/**
- * Removes emitter.
- *
- * @param {Events} emitter - The emitter
- */
-Events.prototype.removeEmitter = function (emitter) {
-    const idx = this._additionalEmitters.indexOf(emitter);
-    if (idx !== -1) {
-        this._additionalEmitters.splice(idx, 1);
+    /**
+     * Adds another emitter. Any events fired by this instance
+     * will also be fired on the additional emitter.
+     *
+     * @param {Events} emitter - The emitter
+     */
+    addEmitter(emitter) {
+        if (!this._additionalEmitters.includes(emitter)) {
+            this._additionalEmitters.push(emitter);
+        }
     }
-};
 
-/**
- * @class
- * @name EventHandle
- * @param {Events} owner - Owner
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- */
-function EventHandle(owner, name, fn) {
-    this.owner = owner;
-    this.name = name;
-    this.fn = fn;
+    /**
+     * Removes emitter.
+     *
+     * @param {Events} emitter - The emitter
+     */
+    removeEmitter(emitter) {
+        const idx = this._additionalEmitters.indexOf(emitter);
+        if (idx !== -1) {
+            this._additionalEmitters.splice(idx, 1);
+        }
+    }
 }
-
-/**
- * @name EventHandle#unbind
- */
-EventHandle.prototype.unbind = function () {
-    if (! this.owner)
-        return;
-
-    this.owner.unbind(this.name, this.fn);
-
-    this.owner = null;
-    this.name = null;
-    this.fn = null;
-};
-
-/**
- * @name EventHandle#call
- */
-EventHandle.prototype.call = function () {
-    if (! this.fn)
-        return;
-
-    this.fn.call(this.owner, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6], arguments[7]);
-};
-
-/**
- * @name EventHandle#on
- * @param {string} name - Name
- * @param {HandleEvent} fn - Callback function
- * @returns {EventHandle} - EventHandle
- */
-EventHandle.prototype.on = function (name, fn) {
-    return this.owner.on(name, fn);
-};
 
 export default Events;

--- a/src/events.js
+++ b/src/events.js
@@ -50,7 +50,7 @@ class Events {
      * @returns {EventHandle} EventHandle
      */
     on(name, fn) {
-        var events = this._events[name];
+        const events = this._events[name];
         if (events === undefined) {
             this._events[name] = [fn];
         } else {
@@ -67,9 +67,8 @@ class Events {
      * @returns {EventHandle} EventHandle
      */
     once(name, fn) {
-        var self = this;
-        var evt = this.on(name, function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
-            fn.call(self, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        const evt = this.on(name, (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) => {
+            fn.call(this, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
             evt.unbind();
         });
         return evt;
@@ -91,12 +90,12 @@ class Events {
     emit(name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
         if (this._suspendEvents) return;
 
-        var events = this._events[name];
+        let events = this._events[name];
         if (events && events.length) {
             events = events.slice(0);
 
-            for (var i = 0; i < events.length; i++) {
-                if (! events[i])
+            for (let i = 0; i < events.length; i++) {
+                if (!events[i])
                     continue;
 
                 try {
@@ -126,12 +125,12 @@ class Events {
      */
     unbind(name, fn) {
         if (name) {
-            var events = this._events[name];
-            if (! events)
+            const events = this._events[name];
+            if (!events)
                 return this;
 
             if (fn) {
-                var i = events.indexOf(fn);
+                const i = events.indexOf(fn);
                 if (i !== -1) {
                     if (events.length === 1) {
                         delete this._events[name];

--- a/src/events.js
+++ b/src/events.js
@@ -2,7 +2,7 @@ import EventHandle from './event-handle.js';
 
 /**
  * @callback HandleEvent
- * @description Callback used by {@link Events} and {@link EventHandle} functions. Note the callback is limited to 8 arguments.
+ * Callback used by {@link Events} and {@link EventHandle} functions. Note the callback is limited to 8 arguments.
  * @param {*} [arg1] - First argument that is passed from caller.
  * @param {*} [arg2] - Second argument that is passed from caller.
  * @param {*} [arg3] - Third argument that is passed from caller.
@@ -14,8 +14,7 @@ import EventHandle from './event-handle.js';
  */
 
 /**
- * @class
- * @name Events
+ * Base class for event handling.
  */
 class Events {
     constructor() {
@@ -44,7 +43,6 @@ class Events {
     }
 
     /**
-     * @name Events#on
      * @param {string} name - Name
      * @param {HandleEvent} fn - Callback function
      * @returns {EventHandle} EventHandle
@@ -61,7 +59,6 @@ class Events {
     }
 
     /**
-     * @name Events#once
      * @param {string} name - Name
      * @param {HandleEvent} fn - Callback function
      * @returns {EventHandle} EventHandle
@@ -75,16 +72,15 @@ class Events {
     }
 
     /**
-     * @name Events#emit
      * @param {string} name - Name
-     * @param {any} arg0 - First argument
-     * @param {any} arg1 - Second argument
-     * @param {any} arg2 - Third argument
-     * @param {any} arg3 - Fourth argument
-     * @param {any} arg4 - Fifth argument
-     * @param {any} arg5 - Sixth argument
-     * @param {any} arg6 - Seventh argument
-     * @param {any} arg7 - Eights argument
+     * @param {*} [arg0] - First argument
+     * @param {*} [arg1] - Second argument
+     * @param {*} [arg2] - Third argument
+     * @param {*} [arg3] - Fourth argument
+     * @param {*} [arg4] - Fifth argument
+     * @param {*} [arg5] - Sixth argument
+     * @param {*} [arg6] - Seventh argument
+     * @param {*} [arg7] - Eights argument
      * @returns {Events} Self for chaining.
      */
     emit(name, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
@@ -118,7 +114,6 @@ class Events {
     }
 
     /**
-     * @name Events#unbind
      * @param {string} name - Name
      * @param {HandleEvent} fn - Callback function
      * @returns {Events} - This

--- a/src/history.js
+++ b/src/history.js
@@ -16,10 +16,6 @@ import Events from './events.js';
  * Manages history actions for undo / redo operations.
  *
  * @augments Events
- * @property {HistoryAction} currentAction Returns the current history action
- * @property {HistoryAction} lastAction Returns the last history action
- * @property {boolean} canUndo Whether we can undo at this time.
- * @property {boolean} canRedo Whether we can redo at this time.
  */
 class History extends Events {
     /**
@@ -143,18 +139,38 @@ class History extends Events {
         this.canRedo = false;
     }
 
+    /**
+     * The current history action.
+     *
+     * @type {HistoryAction}
+     */
     get currentAction() {
         return this._actions[this._currentActionIndex] || null;
     }
 
+    /**
+     * The the last action committed to the history.
+     *
+     * @type {HistoryAction}
+     */
     get lastAction() {
         return this._actions[this._actions.length - 1] || null;
     }
 
+    /**
+     * Whether we can undo at this time.
+     *
+     * @type {boolean}
+     */
     get canUndo() {
         return this._canUndo;
     }
 
+    /**
+     * Returns the last history action.
+     *
+     * @type {boolean}
+     */
     set canUndo(value) {
         if (this._canUndo === value) return;
         this._canUndo = value;

--- a/src/history.js
+++ b/src/history.js
@@ -149,7 +149,7 @@ class History extends Events {
     }
 
     /**
-     * The the last action committed to the history.
+     * The last action committed to the history.
      *
      * @type {HistoryAction}
      */
@@ -166,17 +166,17 @@ class History extends Events {
         return this._canUndo;
     }
 
-    /**
-     * Returns the last history action.
-     *
-     * @type {boolean}
-     */
     set canUndo(value) {
         if (this._canUndo === value) return;
         this._canUndo = value;
         this.emit('canUndo', value);
     }
 
+    /**
+     * Whether we can redo at this time.
+     *
+     * @type {boolean}
+     */
     get canRedo() {
         return this._canRedo;
     }

--- a/src/history.js
+++ b/src/history.js
@@ -13,21 +13,21 @@ import Events from './events.js';
  */
 
 /**
- * @name History
- * @class
- * @classdesc Manages history actions for undo / redo operations.
+ * Manages history actions for undo / redo operations.
+ *
+ * @augments Events
  * @property {HistoryAction} currentAction Returns the current history action
  * @property {HistoryAction} lastAction Returns the last history action
  * @property {boolean} canUndo Whether we can undo at this time.
  * @property {boolean} canRedo Whether we can redo at this time.
- * @augments Events
  */
 class History extends Events {
     /**
-     * Creates a new pcui.History.
+     * Creates a new History.
      */
     constructor() {
         super();
+
         this._actions = [];
         this._currentActionIndex = -1;
         this._canUndo = false;
@@ -35,8 +35,8 @@ class History extends Events {
     }
 
     /**
-     * @name History#add
-     * @description Adds a new history action
+     * Adds a new history action
+     *
      * @param {HistoryAction} action - The action
      */
     add(action) {
@@ -79,8 +79,7 @@ class History extends Events {
     }
 
     /**
-     * @name History#undo
-     * @description Undo the last history action
+     * Undo the last history action
      */
     undo() {
         if (!this.canUndo) return;
@@ -107,8 +106,7 @@ class History extends Events {
     }
 
     /**
-     * @name History#redo
-     * @description Redo the current history action
+     * Redo the current history action
      */
     redo() {
         if (!this.canRedo) return;
@@ -133,8 +131,7 @@ class History extends Events {
     }
 
     /**
-     * @name History#clear
-     * @description Clears all history actions.
+     * Clears all history actions.
      */
     clear() {
         if (!this._actions.length) return;

--- a/src/history.js
+++ b/src/history.js
@@ -1,4 +1,4 @@
-import Events from './events';
+import Events from './events.js';
 
 /**
  * @name HistoryAction
@@ -137,7 +137,7 @@ class History extends Events {
      * @description Clears all history actions.
      */
     clear() {
-        if (! this._actions.length) return;
+        if (!this._actions.length) return;
 
         this._actions.length = 0;
         this._currentActionIndex = -1;

--- a/src/observer-history.js
+++ b/src/observer-history.js
@@ -2,11 +2,14 @@ import Events from './events.js';
 import Observer from './observer.js';
 
 /**
- * @class
- * @name ObserverHistory
- * @param {any} args - Arguments
+ * History for an observer.
+ *
+ * @augments Events
  */
 class ObserverHistory extends Events {
+    /**
+     * @param {any} args - Arguments
+     */
     constructor(args = {}) {
         super();
 

--- a/src/observer-history.js
+++ b/src/observer-history.js
@@ -199,6 +199,9 @@ class ObserverHistory extends Events {
         this.item = null;
     }
 
+    /**
+     * @type {boolean}
+     */
     get enabled() {
         return this._enabled;
     }
@@ -207,6 +210,9 @@ class ObserverHistory extends Events {
         this._enabled = !!value;
     }
 
+    /**
+     * @type {string}
+     */
     get prefix() {
         return this._prefix;
     }
@@ -215,6 +221,9 @@ class ObserverHistory extends Events {
         this._prefix = value || '';
     }
 
+    /**
+     * @type {boolean}
+     */
     get combine() {
         return this._combine;
     }

--- a/src/observer-history.js
+++ b/src/observer-history.js
@@ -6,227 +6,221 @@ import Observer from './observer';
  * @name ObserverHistory
  * @param {any} args - Arguments
  */
-function ObserverHistory(args) {
-    Events.call(this);
+class ObserverHistory extends Events {
+    constructor(args = {}) {
+        super();
 
-    args = args || {};
+        this.item = args.item;
+        this._history = args.history;
+        this._enabled = args.enabled || true;
+        this._prefix = args.prefix || '';
+        this._combine = args.combine || false;
 
-    this.item = args.item;
-    this._history = args.history;
-    this._enabled = args.enabled || true;
-    this._prefix = args.prefix || '';
-    this._combine = args.combine || false;
+        this._events = [];
 
-    this._events = [];
+        this._initialize();
+    }
 
-    this._initialize();
-}
-ObserverHistory.prototype = Object.create(Events.prototype);
+    _initialize() {
+        var self = this;
 
+        this._events.push(this.item.on('*:set', function (path, value, valueOld) {
+            if (!self._enabled || !self._history) return;
 
-ObserverHistory.prototype._initialize = function () {
-    var self = this;
+            // need jsonify
+            if (value instanceof Observer)
+                value = value.json();
 
-    this._events.push(this.item.on('*:set', function (path, value, valueOld) {
-        if (!self._enabled || !self._history) return;
+            // action
+            var action = {
+                name: self._prefix + path,
+                combine: self._combine,
+                undo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-        // need jsonify
-        if (value instanceof Observer)
-            value = value.json();
+                    item.history.enabled = false;
 
-        // action
-        var action = {
-            name: self._prefix + path,
-            combine: self._combine,
-            undo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+                    if (valueOld === undefined) {
+                        item.unset(path);
+                    } else {
+                        item.set(path, valueOld);
+                    }
 
-                item.history.enabled = false;
+                    item.history.enabled = true;
+                },
+                redo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                if (valueOld === undefined) {
-                    item.unset(path);
-                } else {
+                    item.history.enabled = false;
+
+                    if (value === undefined) {
+                        item.unset(path);
+                    } else {
+                        item.set(path, value);
+                    }
+
+                    item.history.enabled = true;
+                }
+            };
+
+            self._history.add(action);
+        }));
+
+        this._events.push(this.item.on('*:unset', function (path, valueOld) {
+            if (!self._enabled || !self._history) return;
+
+            // action
+            var action = {
+                name: self._prefix + path,
+                combine: self._combine,
+                undo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
+
+                    item.history.enabled = false;
                     item.set(path, valueOld);
-                }
+                    item.history.enabled = true;
+                },
+                redo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = true;
-            },
-            redo: function () {
-                var item = self.item.latest();
-                if (!item) return;
-
-                item.history.enabled = false;
-
-                if (value === undefined) {
+                    item.history.enabled = false;
                     item.unset(path);
-                } else {
-                    item.set(path, value);
+                    item.history.enabled = true;
                 }
+            };
 
-                item.history.enabled = true;
-            }
-        };
+            self._history.add(action);
+        }));
 
-        self._history.add(action);
-    }));
+        this._events.push(this.item.on('*:insert', function (path, value, ind) {
+            if (!self._enabled || !self._history) return;
 
-    this._events.push(this.item.on('*:unset', function (path, valueOld) {
-        if (!self._enabled || !self._history) return;
+            // need jsonify
+            // if (value instanceof Observer)
+            //     value = value.json();
 
-        // action
-        var action = {
-            name: self._prefix + path,
-            combine: self._combine,
-            undo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+            // action
+            var action = {
+                name: self._prefix + path,
+                combine: self._combine,
+                undo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = false;
-                item.set(path, valueOld);
-                item.history.enabled = true;
-            },
-            redo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+                    item.history.enabled = false;
+                    item.removeValue(path, value);
+                    item.history.enabled = true;
+                },
+                redo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = false;
-                item.unset(path);
-                item.history.enabled = true;
-            }
-        };
+                    item.history.enabled = false;
+                    item.insert(path, value, ind);
+                    item.history.enabled = true;
+                }
+            };
 
-        self._history.add(action);
-    }));
+            self._history.add(action);
+        }));
 
-    this._events.push(this.item.on('*:insert', function (path, value, ind) {
-        if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:remove', function (path, value, ind) {
+            if (!self._enabled || !self._history) return;
 
-        // need jsonify
-        // if (value instanceof Observer)
-        //     value = value.json();
+            // need jsonify
+            // if (value instanceof Observer)
+            //     value = value.json();
 
-        // action
-        var action = {
-            name: self._prefix + path,
-            combine: self._combine,
-            undo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+            // action
+            var action = {
+                name: self._prefix + path,
+                combine: self._combine,
+                undo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = false;
-                item.removeValue(path, value);
-                item.history.enabled = true;
-            },
-            redo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+                    item.history.enabled = false;
+                    item.insert(path, value, ind);
+                    item.history.enabled = true;
+                },
+                redo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = false;
-                item.insert(path, value, ind);
-                item.history.enabled = true;
-            }
-        };
+                    item.history.enabled = false;
+                    item.removeValue(path, value);
+                    item.history.enabled = true;
+                }
+            };
 
-        self._history.add(action);
-    }));
+            self._history.add(action);
+        }));
 
-    this._events.push(this.item.on('*:remove', function (path, value, ind) {
-        if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:move', function (path, value, ind, indOld) {
+            if (!self._enabled || !self._history) return;
 
-        // need jsonify
-        // if (value instanceof Observer)
-        //     value = value.json();
+            // action
+            var action = {
+                name: self._prefix + path,
+                combine: self._combine,
+                undo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-        // action
-        var action = {
-            name: self._prefix + path,
-            combine: self._combine,
-            undo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+                    item.history.enabled = false;
+                    item.move(path, ind, indOld);
+                    item.history.enabled = true;
+                },
+                redo: function () {
+                    var item = self.item.latest();
+                    if (!item) return;
 
-                item.history.enabled = false;
-                item.insert(path, value, ind);
-                item.history.enabled = true;
-            },
-            redo: function () {
-                var item = self.item.latest();
-                if (!item) return;
+                    item.history.enabled = false;
+                    item.move(path, indOld, ind);
+                    item.history.enabled = true;
+                }
+            };
 
-                item.history.enabled = false;
-                item.removeValue(path, value);
-                item.history.enabled = true;
-            }
-        };
+            self._history.add(action);
+        }));
+    }
 
-        self._history.add(action);
-    }));
+    destroy() {
+        this._events.forEach(function (evt) {
+            evt.unbind();
+        });
 
-    this._events.push(this.item.on('*:move', function (path, value, ind, indOld) {
-        if (!self._enabled || !self._history) return;
+        this._events.length = 0;
+        this.item = null;
+    }
 
-        // action
-        var action = {
-            name: self._prefix + path,
-            combine: self._combine,
-            undo: function () {
-                var item = self.item.latest();
-                if (!item) return;
-
-                item.history.enabled = false;
-                item.move(path, ind, indOld);
-                item.history.enabled = true;
-            },
-            redo: function () {
-                var item = self.item.latest();
-                if (!item) return;
-
-                item.history.enabled = false;
-                item.move(path, indOld, ind);
-                item.history.enabled = true;
-            }
-        };
-
-        self._history.add(action);
-    }));
-};
-
-ObserverHistory.prototype.destroy = function () {
-    this._events.forEach(function (evt) {
-        evt.unbind();
-    });
-
-    this._events.length = 0;
-    this.item = null;
-};
-
-Object.defineProperty(ObserverHistory.prototype, 'enabled', {
-    get: function () {
+    get enabled() {
         return this._enabled;
-    },
-    set: function (value) {
+    }
+
+    set enabled(value) {
         this._enabled = !!value;
     }
-});
 
-
-Object.defineProperty(ObserverHistory.prototype, 'prefix', {
-    get: function () {
+    get prefix() {
         return this._prefix;
-    },
-    set: function (value) {
+    }
+
+    set prefix(value) {
         this._prefix = value || '';
     }
-});
 
-Object.defineProperty(ObserverHistory.prototype, 'combine', {
-    get: function () {
+    get combine() {
         return this._combine;
-    },
-    set: function (value) {
+    }
+
+    set combine(value) {
         this._combine = !! value;
     }
-});
+}
 
 export default ObserverHistory;

--- a/src/observer-history.js
+++ b/src/observer-history.js
@@ -1,5 +1,5 @@
-import Events from './events';
-import Observer from './observer';
+import Events from './events.js';
+import Observer from './observer.js';
 
 /**
  * @class
@@ -22,21 +22,19 @@ class ObserverHistory extends Events {
     }
 
     _initialize() {
-        var self = this;
-
-        this._events.push(this.item.on('*:set', function (path, value, valueOld) {
-            if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:set', (path, value, valueOld) => {
+            if (!this._enabled || !this._history) return;
 
             // need jsonify
             if (value instanceof Observer)
                 value = value.json();
 
             // action
-            var action = {
-                name: self._prefix + path,
-                combine: self._combine,
-                undo: function () {
-                    var item = self.item.latest();
+            const action = {
+                name: this._prefix + path,
+                combine: this._combine,
+                undo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -49,8 +47,8 @@ class ObserverHistory extends Events {
 
                     item.history.enabled = true;
                 },
-                redo: function () {
-                    var item = self.item.latest();
+                redo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -65,26 +63,26 @@ class ObserverHistory extends Events {
                 }
             };
 
-            self._history.add(action);
+            this._history.add(action);
         }));
 
-        this._events.push(this.item.on('*:unset', function (path, valueOld) {
-            if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:unset', (path, valueOld) => {
+            if (!this._enabled || !this._history) return;
 
             // action
-            var action = {
-                name: self._prefix + path,
-                combine: self._combine,
-                undo: function () {
-                    var item = self.item.latest();
+            const action = {
+                name: this._prefix + path,
+                combine: this._combine,
+                undo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
                     item.set(path, valueOld);
                     item.history.enabled = true;
                 },
-                redo: function () {
-                    var item = self.item.latest();
+                redo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -93,30 +91,30 @@ class ObserverHistory extends Events {
                 }
             };
 
-            self._history.add(action);
+            this._history.add(action);
         }));
 
-        this._events.push(this.item.on('*:insert', function (path, value, ind) {
-            if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:insert', (path, value, ind) => {
+            if (!this._enabled || !this._history) return;
 
             // need jsonify
             // if (value instanceof Observer)
             //     value = value.json();
 
             // action
-            var action = {
-                name: self._prefix + path,
-                combine: self._combine,
-                undo: function () {
-                    var item = self.item.latest();
+            const action = {
+                name: this._prefix + path,
+                combine: this._combine,
+                undo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
                     item.removeValue(path, value);
                     item.history.enabled = true;
                 },
-                redo: function () {
-                    var item = self.item.latest();
+                redo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -125,30 +123,30 @@ class ObserverHistory extends Events {
                 }
             };
 
-            self._history.add(action);
+            this._history.add(action);
         }));
 
-        this._events.push(this.item.on('*:remove', function (path, value, ind) {
-            if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:remove', (path, value, ind) => {
+            if (!this._enabled || !this._history) return;
 
             // need jsonify
             // if (value instanceof Observer)
             //     value = value.json();
 
             // action
-            var action = {
-                name: self._prefix + path,
-                combine: self._combine,
-                undo: function () {
-                    var item = self.item.latest();
+            const action = {
+                name: this._prefix + path,
+                combine: this._combine,
+                undo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
                     item.insert(path, value, ind);
                     item.history.enabled = true;
                 },
-                redo: function () {
-                    var item = self.item.latest();
+                redo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -157,26 +155,26 @@ class ObserverHistory extends Events {
                 }
             };
 
-            self._history.add(action);
+            this._history.add(action);
         }));
 
-        this._events.push(this.item.on('*:move', function (path, value, ind, indOld) {
-            if (!self._enabled || !self._history) return;
+        this._events.push(this.item.on('*:move', (path, value, ind, indOld) => {
+            if (!this._enabled || !this._history) return;
 
             // action
-            var action = {
-                name: self._prefix + path,
-                combine: self._combine,
-                undo: function () {
-                    var item = self.item.latest();
+            const action = {
+                name: this._prefix + path,
+                combine: this._combine,
+                undo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
                     item.move(path, ind, indOld);
                     item.history.enabled = true;
                 },
-                redo: function () {
-                    var item = self.item.latest();
+                redo: () => {
+                    const item = this.item.latest();
                     if (!item) return;
 
                     item.history.enabled = false;
@@ -185,12 +183,12 @@ class ObserverHistory extends Events {
                 }
             };
 
-            self._history.add(action);
+            this._history.add(action);
         }));
     }
 
     destroy() {
-        this._events.forEach(function (evt) {
+        this._events.forEach((evt) => {
             evt.unbind();
         });
 
@@ -219,7 +217,7 @@ class ObserverHistory extends Events {
     }
 
     set combine(value) {
-        this._combine = !! value;
+        this._combine = !!value;
     }
 }
 

--- a/src/observer-list.js
+++ b/src/observer-list.js
@@ -2,11 +2,16 @@ import Events from './events.js';
 import Observer from './observer.js';
 
 /**
- * @class
- * @name ObserverList
- * @param {any} options - Options
+ * A list of observers.
+ *
+ * @augments Events
  */
 class ObserverList extends Events {
+    /**
+     * @param {object} [options] - Options
+     * @param {boolean} [options.sorted] - Sorted
+     * @param {string} [options.index] - Index
+     */
     constructor(options = {}) {
         super();
 

--- a/src/observer-list.js
+++ b/src/observer-list.js
@@ -1,5 +1,5 @@
-import Events from './events';
-import Observer from './observer';
+import Events from './events.js';
+import Observer from './observer.js';
 
 /**
  * @class
@@ -38,20 +38,20 @@ class ObserverList extends Events {
 
     indexOf(item) {
         if (this.index) {
-            var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            const index = (item instanceof Observer && item.get(this.index)) || item[this.index];
             return (this._indexed[index] && index) || null;
         }
 
-        var ind = this.data.indexOf(item);
+        const ind = this.data.indexOf(item);
         return ind !== -1 ? ind : null;
     }
 
     position(b, fn) {
-        var l = this.data;
-        var min = 0;
-        var max = l.length - 1;
-        var cur;
-        var a, i;
+        const l = this.data;
+        let min = 0;
+        let max = l.length - 1;
+        let cur;
+        let a, i;
         fn = fn || this.sorted;
 
         while (min <= max) {
@@ -73,11 +73,11 @@ class ObserverList extends Events {
     }
 
     positionNextClosest(b, fn) {
-        var l = this.data;
-        var min = 0;
-        var max = l.length - 1;
-        var cur;
-        var a, i;
+        const l = this.data;
+        let min = 0;
+        let max = l.length - 1;
+        let cur;
+        let a, i;
         fn = fn || this.sorted;
 
         if (l.length === 0)
@@ -112,8 +112,8 @@ class ObserverList extends Events {
 
     has(item) {
         if (this.index) {
-            var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
-            return !! this._indexed[index];
+            const index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            return !!this._indexed[index];
         }
 
         return this.data.indexOf(item) !== -1;
@@ -123,13 +123,13 @@ class ObserverList extends Events {
         if (this.has(item))
             return null;
 
-        var index = this.data.length;
+        let index = this.data.length;
         if (this.index) {
             index = (item instanceof Observer && item.get(this.index)) || item[this.index];
             this._indexed[index] = item;
         }
 
-        var pos = 0;
+        let pos = 0;
 
         if (this.sorted) {
             pos = this.positionNextClosest(item);
@@ -155,7 +155,7 @@ class ObserverList extends Events {
     }
 
     move(item, pos) {
-        var ind = this.data.indexOf(item);
+        const ind = this.data.indexOf(item);
         this.data.splice(ind, 1);
         if (pos === -1) {
             this.data.push(item);
@@ -167,12 +167,12 @@ class ObserverList extends Events {
     }
 
     remove(item) {
-        if (! this.has(item))
+        if (!this.has(item))
             return;
 
-        var ind = this.data.indexOf(item);
+        const ind = this.data.indexOf(item);
 
-        var index = ind;
+        let index = ind;
         if (this.index) {
             index = (item instanceof Observer && item.get(this.index)) || item[this.index];
             delete this._indexed[index];
@@ -184,15 +184,15 @@ class ObserverList extends Events {
     }
 
     removeByKey(index) {
-        var item;
+        let item;
 
         if (this.index) {
             item = this._indexed[index];
 
-            if (! item)
+            if (!item)
                 return;
 
-            var ind = this.data.indexOf(item);
+            const ind = this.data.indexOf(item);
             this.data.splice(ind, 1);
 
             delete this._indexed[index];
@@ -211,9 +211,9 @@ class ObserverList extends Events {
     }
 
     removeBy(fn) {
-        var i = this.data.length;
+        let i = this.data.length;
         while (i--) {
-            if (! fn(this.data[i]))
+            if (!fn(this.data[i]))
                 continue;
 
             if (this.index) {
@@ -226,30 +226,30 @@ class ObserverList extends Events {
     }
 
     clear() {
-        var items = this.data.slice(0);
+        const items = this.data.slice(0);
 
         this.data = [];
         this._indexed = { };
 
-        var i = items.length;
+        let i = items.length;
         while (i--) {
             this.emit('remove', items[i], i);
         }
     }
 
     forEach(fn) {
-        for (var i = 0; i < this.data.length; i++) {
+        for (let i = 0; i < this.data.length; i++) {
             fn(this.data[i], (this.index && this.data[i][this.index]) || i);
         }
     }
 
     find(fn) {
-        var items = [];
-        for (var i = 0; i < this.data.length; i++) {
-            if (! fn(this.data[i]))
+        const items = [];
+        for (let i = 0; i < this.data.length; i++) {
+            if (!fn(this.data[i]))
                 continue;
 
-            var index = i;
+            let index = i;
             if (this.index)
                 index = this.data[i][this.index];
 
@@ -259,11 +259,11 @@ class ObserverList extends Events {
     }
 
     findOne(fn) {
-        for (var i = 0; i < this.data.length; i++) {
-            if (! fn(this.data[i]))
+        for (let i = 0; i < this.data.length; i++) {
+            if (!fn(this.data[i]))
                 continue;
 
-            var index = i;
+            let index = i;
             if (this.index)
                 index = this.data[i][this.index];
 
@@ -285,8 +285,8 @@ class ObserverList extends Events {
     }
 
     json() {
-        var items = this.array();
-        for (var i = 0; i < items.length; i++) {
+        const items = this.array();
+        for (let i = 0; i < items.length; i++) {
             if (items[i] instanceof Observer) {
                 items[i] = items[i].json();
             }

--- a/src/observer-list.js
+++ b/src/observer-list.js
@@ -6,316 +6,293 @@ import Observer from './observer';
  * @name ObserverList
  * @param {any} options - Options
  */
-function ObserverList(options) {
-    Events.call(this);
-    options = options || { };
+class ObserverList extends Events {
+    constructor(options = {}) {
+        super();
 
-    this.data = [];
-    this._indexed = { };
-    this.sorted = options.sorted || null;
-    this.index = options.index || null;
-}
+        this.data = [];
+        this._indexed = { };
+        this.sorted = options.sorted || null;
+        this.index = options.index || null;
+    }
 
-ObserverList.prototype = Object.create(Events.prototype);
-
-
-Object.defineProperty(ObserverList.prototype, 'length', {
-    get: function () {
+    get length() {
         return this.data.length;
     }
-});
 
+    get(index) {
+        if (this.index) {
+            return this._indexed[index] || null;
+        }
 
-ObserverList.prototype.get = function (index) {
-    if (this.index) {
-        return this._indexed[index] || null;
+        return this.data[index] || null;
     }
 
-    return this.data[index] || null;
-};
-
-
-ObserverList.prototype.set = function (index, value) {
-    if (this.index) {
-        this._indexed[index] = value;
-    } else {
-        this.data[index] = value;
-    }
-};
-
-
-ObserverList.prototype.indexOf = function (item) {
-    if (this.index) {
-        var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
-        return (this._indexed[index] && index) || null;
-    }
-
-    var ind = this.data.indexOf(item);
-    return ind !== -1 ? ind : null;
-};
-
-
-ObserverList.prototype.position = function (b, fn) {
-    var l = this.data;
-    var min = 0;
-    var max = l.length - 1;
-    var cur;
-    var a, i;
-    fn = fn || this.sorted;
-
-    while (min <= max) {
-        cur = Math.floor((min + max) / 2);
-        a = l[cur];
-
-        i = fn(a, b);
-
-        if (i === 1) {
-            max = cur - 1;
-        } else if (i === -1) {
-            min = cur + 1;
+    set(index, value) {
+        if (this.index) {
+            this._indexed[index] = value;
         } else {
-            return cur;
+            this.data[index] = value;
         }
     }
 
-    return -1;
-};
-
-
-ObserverList.prototype.positionNextClosest = function (b, fn) {
-    var l = this.data;
-    var min = 0;
-    var max = l.length - 1;
-    var cur;
-    var a, i;
-    fn = fn || this.sorted;
-
-    if (l.length === 0)
-        return -1;
-
-    if (fn(l[0], b) === 0)
-        return 0;
-
-    while (min <= max) {
-        cur = Math.floor((min + max) / 2);
-        a = l[cur];
-
-        i = fn(a, b);
-
-        if (i === 1) {
-            max = cur - 1;
-        } else if (i === -1) {
-            min = cur + 1;
-        } else {
-            return cur;
+    indexOf(item) {
+        if (this.index) {
+            var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            return (this._indexed[index] && index) || null;
         }
+
+        var ind = this.data.indexOf(item);
+        return ind !== -1 ? ind : null;
     }
 
-    if (fn(a, b) === 1)
-        return cur;
+    position(b, fn) {
+        var l = this.data;
+        var min = 0;
+        var max = l.length - 1;
+        var cur;
+        var a, i;
+        fn = fn || this.sorted;
 
-    if ((cur + 1) === l.length)
+        while (min <= max) {
+            cur = Math.floor((min + max) / 2);
+            a = l[cur];
+
+            i = fn(a, b);
+
+            if (i === 1) {
+                max = cur - 1;
+            } else if (i === -1) {
+                min = cur + 1;
+            } else {
+                return cur;
+            }
+        }
+
         return -1;
-
-    return cur + 1;
-};
-
-
-ObserverList.prototype.has = function (item) {
-    if (this.index) {
-        var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
-        return !! this._indexed[index];
     }
 
-    return this.data.indexOf(item) !== -1;
-};
+    positionNextClosest(b, fn) {
+        var l = this.data;
+        var min = 0;
+        var max = l.length - 1;
+        var cur;
+        var a, i;
+        fn = fn || this.sorted;
 
+        if (l.length === 0)
+            return -1;
 
-ObserverList.prototype.add = function (item) {
-    if (this.has(item))
-        return null;
+        if (fn(l[0], b) === 0)
+            return 0;
 
-    var index = this.data.length;
-    if (this.index) {
-        index = (item instanceof Observer && item.get(this.index)) || item[this.index];
-        this._indexed[index] = item;
+        while (min <= max) {
+            cur = Math.floor((min + max) / 2);
+            a = l[cur];
+
+            i = fn(a, b);
+
+            if (i === 1) {
+                max = cur - 1;
+            } else if (i === -1) {
+                min = cur + 1;
+            } else {
+                return cur;
+            }
+        }
+
+        if (fn(a, b) === 1)
+            return cur;
+
+        if ((cur + 1) === l.length)
+            return -1;
+
+        return cur + 1;
     }
 
-    var pos = 0;
+    has(item) {
+        if (this.index) {
+            var index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            return !! this._indexed[index];
+        }
 
-    if (this.sorted) {
-        pos = this.positionNextClosest(item);
-        if (pos !== -1) {
-            this.data.splice(pos, 0, item);
+        return this.data.indexOf(item) !== -1;
+    }
+
+    add(item) {
+        if (this.has(item))
+            return null;
+
+        var index = this.data.length;
+        if (this.index) {
+            index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            this._indexed[index] = item;
+        }
+
+        var pos = 0;
+
+        if (this.sorted) {
+            pos = this.positionNextClosest(item);
+            if (pos !== -1) {
+                this.data.splice(pos, 0, item);
+            } else {
+                this.data.push(item);
+            }
         } else {
             this.data.push(item);
+            pos = this.data.length - 1;
         }
-    } else {
-        this.data.push(item);
-        pos = this.data.length - 1;
-    }
 
-    this.emit('add', item, index, pos);
-    if (this.index) {
-        const id = item.get(this.index);
-        if (id) {
-            this.emit(`add[${id}]`, item, index, pos);
+        this.emit('add', item, index, pos);
+        if (this.index) {
+            const id = item.get(this.index);
+            if (id) {
+                this.emit(`add[${id}]`, item, index, pos);
+            }
         }
+
+        return pos;
     }
 
-    return pos;
-};
+    move(item, pos) {
+        var ind = this.data.indexOf(item);
+        this.data.splice(ind, 1);
+        if (pos === -1) {
+            this.data.push(item);
+        } else {
+            this.data.splice(pos, 0, item);
+        }
 
-
-ObserverList.prototype.move = function (item, pos) {
-    var ind = this.data.indexOf(item);
-    this.data.splice(ind, 1);
-    if (pos === -1) {
-        this.data.push(item);
-    } else {
-        this.data.splice(pos, 0, item);
+        this.emit('move', item, pos);
     }
 
-    this.emit('move', item, pos);
-};
-
-
-ObserverList.prototype.remove = function (item) {
-    if (! this.has(item))
-        return;
-
-    var ind = this.data.indexOf(item);
-
-    var index = ind;
-    if (this.index) {
-        index = (item instanceof Observer && item.get(this.index)) || item[this.index];
-        delete this._indexed[index];
-    }
-
-    this.data.splice(ind, 1);
-
-    this.emit('remove', item, index);
-};
-
-
-ObserverList.prototype.removeByKey = function (index) {
-    var item;
-
-    if (this.index) {
-        item = this._indexed[index];
-
-        if (! item)
+    remove(item) {
+        if (! this.has(item))
             return;
 
         var ind = this.data.indexOf(item);
+
+        var index = ind;
+        if (this.index) {
+            index = (item instanceof Observer && item.get(this.index)) || item[this.index];
+            delete this._indexed[index];
+        }
+
         this.data.splice(ind, 1);
-
-        delete this._indexed[index];
-
-        this.emit('remove', item, ind);
-    } else {
-        if (this.data.length < index)
-            return;
-
-        item = this.data[index];
-
-        this.data.splice(index, 1);
 
         this.emit('remove', item, index);
     }
-};
 
-
-ObserverList.prototype.removeBy = function (fn) {
-    var i = this.data.length;
-    while (i--) {
-        if (! fn(this.data[i]))
-            continue;
+    removeByKey(index) {
+        var item;
 
         if (this.index) {
-            delete this._indexed[this.data[i][this.index]];
-        }
-        this.data.splice(i, 1);
+            item = this._indexed[index];
 
-        this.emit('remove', this.data[i], i);
-    }
-};
+            if (! item)
+                return;
 
+            var ind = this.data.indexOf(item);
+            this.data.splice(ind, 1);
 
-ObserverList.prototype.clear = function () {
-    var items = this.data.slice(0);
+            delete this._indexed[index];
 
-    this.data = [];
-    this._indexed = { };
+            this.emit('remove', item, ind);
+        } else {
+            if (this.data.length < index)
+                return;
 
-    var i = items.length;
-    while (i--) {
-        this.emit('remove', items[i], i);
-    }
-};
+            item = this.data[index];
 
+            this.data.splice(index, 1);
 
-ObserverList.prototype.forEach = function (fn) {
-    for (var i = 0; i < this.data.length; i++) {
-        fn(this.data[i], (this.index && this.data[i][this.index]) || i);
-    }
-};
-
-
-ObserverList.prototype.find = function (fn) {
-    var items = [];
-    for (var i = 0; i < this.data.length; i++) {
-        if (! fn(this.data[i]))
-            continue;
-
-        var index = i;
-        if (this.index)
-            index = this.data[i][this.index];
-
-        items.push([index, this.data[i]]);
-    }
-    return items;
-};
-
-
-ObserverList.prototype.findOne = function (fn) {
-    for (var i = 0; i < this.data.length; i++) {
-        if (! fn(this.data[i]))
-            continue;
-
-        var index = i;
-        if (this.index)
-            index = this.data[i][this.index];
-
-        return [index, this.data[i]];
-    }
-    return null;
-};
-
-
-ObserverList.prototype.map = function (fn) {
-    return this.data.map(fn);
-};
-
-
-ObserverList.prototype.sort = function (fn) {
-    this.data.sort(fn);
-};
-
-
-ObserverList.prototype.array = function () {
-    return this.data.slice(0);
-};
-
-
-ObserverList.prototype.json = function () {
-    var items = this.array();
-    for (var i = 0; i < items.length; i++) {
-        if (items[i] instanceof Observer) {
-            items[i] = items[i].json();
+            this.emit('remove', item, index);
         }
     }
-    return items;
-};
+
+    removeBy(fn) {
+        var i = this.data.length;
+        while (i--) {
+            if (! fn(this.data[i]))
+                continue;
+
+            if (this.index) {
+                delete this._indexed[this.data[i][this.index]];
+            }
+            this.data.splice(i, 1);
+
+            this.emit('remove', this.data[i], i);
+        }
+    }
+
+    clear() {
+        var items = this.data.slice(0);
+
+        this.data = [];
+        this._indexed = { };
+
+        var i = items.length;
+        while (i--) {
+            this.emit('remove', items[i], i);
+        }
+    }
+
+    forEach(fn) {
+        for (var i = 0; i < this.data.length; i++) {
+            fn(this.data[i], (this.index && this.data[i][this.index]) || i);
+        }
+    }
+
+    find(fn) {
+        var items = [];
+        for (var i = 0; i < this.data.length; i++) {
+            if (! fn(this.data[i]))
+                continue;
+
+            var index = i;
+            if (this.index)
+                index = this.data[i][this.index];
+
+            items.push([index, this.data[i]]);
+        }
+        return items;
+    }
+
+    findOne(fn) {
+        for (var i = 0; i < this.data.length; i++) {
+            if (! fn(this.data[i]))
+                continue;
+
+            var index = i;
+            if (this.index)
+                index = this.data[i][this.index];
+
+            return [index, this.data[i]];
+        }
+        return null;
+    }
+
+    map(fn) {
+        return this.data.map(fn);
+    }
+
+    sort(fn) {
+        this.data.sort(fn);
+    }
+
+    array() {
+        return this.data.slice(0);
+    }
+
+    json() {
+        var items = this.array();
+        for (var i = 0; i < items.length; i++) {
+            if (items[i] instanceof Observer) {
+                items[i] = items[i].json();
+            }
+        }
+        return items;
+    }
+}
 
 export default ObserverList;

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,4 +1,4 @@
-import Events from './events';
+import Events from './events.js';
 
 /**
  * @class
@@ -6,940 +6,923 @@ import Events from './events';
  * @param {any} data - Data
  * @param {any} options - Options
  */
-function Observer(data, options) {
-    Events.call(this);
-    options = options || { };
+class Observer extends Events {
+    constructor(data, options = {}) {
+        super();
 
-    this._destroyed = false;
-    this._path = '';
-    this._keys = [];
-    this._data = { };
+        this._destroyed = false;
+        this._path = '';
+        this._keys = [];
+        this._data = { };
 
-    // array paths where duplicate entries are allowed - normally
-    // we check if an array already has a value before inserting it
-    // but if the array path is in here we'll allow it
-    this._pathsWithDuplicates = null;
-    if (options.pathsWithDuplicates) {
-        this._pathsWithDuplicates = {};
-        for (var i = 0; i < options.pathsWithDuplicates.length; i++) {
-            this._pathsWithDuplicates[options.pathsWithDuplicates[i]] = true;
+        // array paths where duplicate entries are allowed - normally
+        // we check if an array already has a value before inserting it
+        // but if the array path is in here we'll allow it
+        this._pathsWithDuplicates = null;
+        if (options.pathsWithDuplicates) {
+            this._pathsWithDuplicates = {};
+            for (var i = 0; i < options.pathsWithDuplicates.length; i++) {
+                this._pathsWithDuplicates[options.pathsWithDuplicates[i]] = true;
+            }
         }
-    }
 
-    this.patch(data);
+        this.patch(data);
 
-    this._parent = options.parent || null;
-    this._parentPath = options.parentPath || '';
-    this._parentField = options.parentField || null;
-    this._parentKey = options.parentKey || null;
+        this._parent = options.parent || null;
+        this._parentPath = options.parentPath || '';
+        this._parentField = options.parentField || null;
+        this._parentKey = options.parentKey || null;
 
-    this._latestFn = options.latestFn || null;
+        this._latestFn = options.latestFn || null;
 
-    this._silent = false;
+        this._silent = false;
 
-    var propagate = function (evt) {
-        return function (path, arg1, arg2, arg3) {
-            if (! this._parent)
-                return;
-
-            var key = this._parentKey;
-            if (! key && (this._parentField instanceof Array)) {
-                key = this._parentField.indexOf(this);
-
-                if (key === -1)
+        var propagate = function (evt) {
+            return function (path, arg1, arg2, arg3) {
+                if (! this._parent)
                     return;
-            }
 
-            path = this._parentPath + '.' + key + '.' + path;
+                var key = this._parentKey;
+                if (! key && (this._parentField instanceof Array)) {
+                    key = this._parentField.indexOf(this);
 
-            var state;
-            if (this._silent)
-                state = this._parent.silence();
-
-            this._parent.emit(path + ':' + evt, arg1, arg2, arg3);
-            this._parent.emit('*:' + evt, path, arg1, arg2, arg3);
-
-            if (this._silent)
-                this._parent.silenceRestore(state);
-        };
-    };
-
-    // propagate set
-    this.on('*:set', propagate('set'));
-    this.on('*:unset', propagate('unset'));
-    this.on('*:insert', propagate('insert'));
-    this.on('*:remove', propagate('remove'));
-    this.on('*:move', propagate('move'));
-}
-
-// cache calls to path.split(path, '.')
-// as they take considerable time especially during loading
-// if there are a lot of observers like entities, assets etc.
-Observer._splitPathsCache = {};
-Observer._splitPath = function (path) {
-    var cache = Observer._splitPathsCache;
-    var result = cache[path];
-    if (!result) {
-        result = path.split('.');
-        cache[path] = result;
-    } else {
-        result = result.slice();
-    }
-
-    return result;
-};
-
-Observer.prototype = Object.create(Events.prototype);
-
-
-Observer.prototype.silence = function () {
-    this._silent = true;
-
-    // history hook to prevent array values to be recorded
-    var historyState = this.history && this.history.enabled;
-    if (historyState)
-        this.history.enabled = false;
-
-    // sync hook to prevent array values to be recorded as array root already did
-    var syncState = this.sync && this.sync.enabled;
-    if (syncState)
-        this.sync.enabled = false;
-
-    return [historyState, syncState];
-};
-
-
-Observer.prototype.silenceRestore = function (state) {
-    this._silent = false;
-
-    if (state[0])
-        this.history.enabled = true;
-
-    if (state[1])
-        this.sync.enabled = true;
-};
-
-
-Observer.prototype._prepare = function (target, key, value, silent, remote) {
-    var i;
-    var state;
-    var path = (target._path ? (target._path + '.') : '') + key;
-    var type = typeof(value);
-
-    target._keys.push(key);
-
-    if (type === 'object' && (value instanceof Array)) {
-        target._data[key] = value.slice(0);
-
-        for (i = 0; i < target._data[key].length; i++) {
-            if (typeof(target._data[key][i]) === 'object' && target._data[key][i] !== null) {
-                if (target._data[key][i] instanceof Array) {
-                    target._data[key][i].slice(0);
-                } else {
-                    target._data[key][i] = new Observer(target._data[key][i], {
-                        parent: this,
-                        parentPath: path,
-                        parentField: target._data[key],
-                        parentKey: null
-                    });
+                    if (key === -1)
+                        return;
                 }
-            } else {
-                state = this.silence();
-                this.emit(path + '.' + i + ':set', target._data[key][i], null, remote);
-                this.emit('*:set', path + '.' + i, target._data[key][i], null, remote);
-                this.silenceRestore(state);
-            }
-        }
 
-        if (silent)
-            state = this.silence();
+                path = this._parentPath + '.' + key + '.' + path;
 
-        this.emit(path + ':set', target._data[key], null, remote);
-        this.emit('*:set', path, target._data[key], null, remote);
+                var state;
+                if (this._silent)
+                    state = this._parent.silence();
 
-        if (silent)
-            this.silenceRestore(state);
-    } else if (type === 'object' && (value instanceof Object)) {
-        if (typeof(target._data[key]) !== 'object') {
-            target._data[key] = {
-                _path: path,
-                _keys: [],
-                _data: { }
+                this._parent.emit(path + ':' + evt, arg1, arg2, arg3);
+                this._parent.emit('*:' + evt, path, arg1, arg2, arg3);
+
+                if (this._silent)
+                    this._parent.silenceRestore(state);
             };
-        }
+        };
 
-        for (i in value) {
-            if (typeof(value[i]) === 'object') {
-                this._prepare(target._data[key], i, value[i], true, remote);
-            } else {
-                state = this.silence();
-
-                target._data[key]._data[i] = value[i];
-                target._data[key]._keys.push(i);
-
-                this.emit(path + '.' + i + ':set', value[i], null, remote);
-                this.emit('*:set', path + '.' + i, value[i], null, remote);
-
-                this.silenceRestore(state);
-            }
-        }
-
-        if (silent)
-            state = this.silence();
-
-        // passing undefined as valueOld here
-        // but we should get the old value to be consistent
-        this.emit(path + ':set', value, undefined, remote);
-        this.emit('*:set', path, value, undefined, remote);
-
-        if (silent)
-            this.silenceRestore(state);
-    } else {
-        if (silent)
-            state = this.silence();
-
-        target._data[key] = value;
-
-        this.emit(path + ':set', value, undefined, remote);
-        this.emit('*:set', path, value, undefined, remote);
-
-        if (silent)
-            this.silenceRestore(state);
+        // propagate set
+        this.on('*:set', propagate('set'));
+        this.on('*:unset', propagate('unset'));
+        this.on('*:insert', propagate('insert'));
+        this.on('*:remove', propagate('remove'));
+        this.on('*:move', propagate('move'));
     }
 
-    return true;
-};
+    // cache calls to path.split(path, '.')
+    // as they take considerable time especially during loading
+    // if there are a lot of observers like entities, assets etc.
+    static _splitPathsCache = {};
 
-
-Observer.prototype.set = function (path, value, silent, remote, force) {
-    var i;
-    var valueOld;
-    var keys = Observer._splitPath(path);
-    var length = keys.length;
-    var key = keys[length - 1];
-    var node = this;
-    var nodePath = '';
-    var obj = this;
-    var state;
-
-    for (i = 0; i < length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[keys[i]];
-
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
-                obj = node;
-            }
+    static _splitPath(path) {
+        var cache = Observer._splitPathsCache;
+        var result = cache[path];
+        if (!result) {
+            result = path.split('.');
+            cache[path] = result;
         } else {
-            if (i < length && typeof(node._data[keys[i]]) !== 'object') {
-                if (node._data[keys[i]])
-                    obj.unset((node.__path ? node.__path + '.' : '') + keys[i]);
+            result = result.slice();
+        }
 
-                node._data[keys[i]] = {
+        return result;
+    }
+
+    silence() {
+        this._silent = true;
+
+        // history hook to prevent array values to be recorded
+        var historyState = this.history && this.history.enabled;
+        if (historyState)
+            this.history.enabled = false;
+
+        // sync hook to prevent array values to be recorded as array root already did
+        var syncState = this.sync && this.sync.enabled;
+        if (syncState)
+            this.sync.enabled = false;
+
+        return [historyState, syncState];
+    }
+
+    silenceRestore(state) {
+        this._silent = false;
+
+        if (state[0])
+            this.history.enabled = true;
+
+        if (state[1])
+            this.sync.enabled = true;
+    }
+
+    _prepare(target, key, value, silent, remote) {
+        var i;
+        var state;
+        var path = (target._path ? (target._path + '.') : '') + key;
+        var type = typeof(value);
+
+        target._keys.push(key);
+
+        if (type === 'object' && (value instanceof Array)) {
+            target._data[key] = value.slice(0);
+
+            for (i = 0; i < target._data[key].length; i++) {
+                if (typeof(target._data[key][i]) === 'object' && target._data[key][i] !== null) {
+                    if (target._data[key][i] instanceof Array) {
+                        target._data[key][i].slice(0);
+                    } else {
+                        target._data[key][i] = new Observer(target._data[key][i], {
+                            parent: this,
+                            parentPath: path,
+                            parentField: target._data[key],
+                            parentKey: null
+                        });
+                    }
+                } else {
+                    state = this.silence();
+                    this.emit(path + '.' + i + ':set', target._data[key][i], null, remote);
+                    this.emit('*:set', path + '.' + i, target._data[key][i], null, remote);
+                    this.silenceRestore(state);
+                }
+            }
+
+            if (silent)
+                state = this.silence();
+
+            this.emit(path + ':set', target._data[key], null, remote);
+            this.emit('*:set', path, target._data[key], null, remote);
+
+            if (silent)
+                this.silenceRestore(state);
+        } else if (type === 'object' && (value instanceof Object)) {
+            if (typeof(target._data[key]) !== 'object') {
+                target._data[key] = {
                     _path: path,
                     _keys: [],
                     _data: { }
                 };
-                node._keys.push(keys[i]);
             }
 
-            if (i === length - 1 && node.__path)
-                nodePath = node.__path + '.' + keys[i];
-
-            node = node._data[keys[i]];
-        }
-    }
-
-    if (node instanceof Array) {
-        var ind = parseInt(key, 10);
-        if (node[ind] === value && !force)
-            return;
-
-        valueOld = node[ind];
-        if (valueOld instanceof Observer) {
-            valueOld = valueOld.json();
-        } else {
-            valueOld = obj.json(valueOld);
-        }
-
-        node[ind] = value;
-
-        if (value instanceof Observer) {
-            value._parent = obj;
-            value._parentPath = nodePath;
-            value._parentField = node;
-            value._parentKey = null;
-        }
-
-        if (silent)
-            state = obj.silence();
-
-        obj.emit(path + ':set', value, valueOld, remote);
-        obj.emit('*:set', path, value, valueOld, remote);
-
-        if (silent)
-            obj.silenceRestore(state);
-
-        return true;
-    } else if (node._data && ! node._data.hasOwnProperty(key)) {
-        if (typeof(value) === 'object') {
-            return obj._prepare(node, key, value, false, remote);
-        }
-        node._data[key] = value;
-        node._keys.push(key);
-
-        if (silent)
-            state = obj.silence();
-
-        obj.emit(path + ':set', value, null, remote);
-        obj.emit('*:set', path, value, null, remote);
-
-        if (silent)
-            obj.silenceRestore(state);
-
-        return true;
-
-    }
-    if (typeof(value) === 'object' && (value instanceof Array)) {
-        if (value.equals(node._data[key]) && !force)
-            return false;
-
-        valueOld = node._data[key];
-        if (! (valueOld instanceof Observer))
-            valueOld = obj.json(valueOld);
-
-        if (node._data[key] && node._data[key].length === value.length) {
-            state = obj.silence();
-
-                // handle new array instance
-            if (value.length === 0) {
-                node._data[key] = value;
-            }
-
-            for (i = 0; i < node._data[key].length; i++) {
-                if (node._data[key][i] instanceof Observer) {
-                    node._data[key][i].patch(value[i], true);
-                } else if (node._data[key][i] !== value[i]) {
-                    node._data[key][i] = value[i];
-                    obj.emit(path + '.' + i + ':set', node._data[key][i], valueOld && valueOld[i] || null, remote);
-                    obj.emit('*:set', path + '.' + i, node._data[key][i], valueOld && valueOld[i] || null, remote);
-                }
-            }
-
-            obj.silenceRestore(state);
-        } else {
-            node._data[key] = [];
-            value.forEach((val) => {
-                this._doInsert(node, key, val, undefined, true);
-            });
-
-            state = obj.silence();
-
-            for (i = 0; i < node._data[key].length; i++) {
-                obj.emit(path + '.' + i + ':set', node._data[key][i], valueOld && valueOld[i] || null, remote);
-                obj.emit('*:set', path + '.' + i, node._data[key][i], valueOld && valueOld[i] || null, remote);
-            }
-            obj.silenceRestore(state);
-        }
-
-        if (silent)
-            state = obj.silence();
-
-        obj.emit(path + ':set', value, valueOld, remote);
-        obj.emit('*:set', path, value, valueOld, remote);
-
-        if (silent)
-            obj.silenceRestore(state);
-
-        return true;
-    } else if (typeof(value) === 'object' && (value instanceof Object)) {
-        var changed = false;
-        valueOld = node._data[key];
-        if (! (valueOld instanceof Observer))
-            valueOld = obj.json(valueOld);
-
-        keys = Object.keys(value);
-
-        if (! node._data[key] || ! node._data[key]._data) {
-            if (node._data[key]) {
-                obj.unset((node.__path ? node.__path + '.' : '') + key);
-            } else {
-                changed = true;
-            }
-
-            node._data[key] = {
-                _path: path,
-                _keys: [],
-                _data: { }
-            };
-        }
-
-        var c;
-
-        for (var n in node._data[key]._data) {
-            if (! value.hasOwnProperty(n)) {
-                c = obj.unset(path + '.' + n, true);
-                if (c) changed = true;
-            } else if (node._data[key]._data.hasOwnProperty(n)) {
-                if (! obj._equals(node._data[key]._data[n], value[n])) {
-                    c = obj.set(path + '.' + n, value[n], true);
-                    if (c) changed = true;
-                }
-            } else {
-                c = obj._prepare(node._data[key], n, value[n], true, remote);
-                if (c) changed = true;
-            }
-        }
-
-        for (i = 0; i < keys.length; i++) {
-            if (value[keys[i]] === undefined && node._data[key]._data.hasOwnProperty(keys[i])) {
-                c = obj.unset(path + '.' + keys[i], true);
-                if (c) changed = true;
-            } else if (typeof(value[keys[i]]) === 'object') {
-                if (node._data[key]._data.hasOwnProperty(keys[i])) {
-                    c = obj.set(path + '.' + keys[i], value[keys[i]], true);
-                    if (c) changed = true;
+            for (i in value) {
+                if (typeof(value[i]) === 'object') {
+                    this._prepare(target._data[key], i, value[i], true, remote);
                 } else {
-                    c = obj._prepare(node._data[key], keys[i], value[keys[i]], true, remote);
-                    if (c) changed = true;
+                    state = this.silence();
+
+                    target._data[key]._data[i] = value[i];
+                    target._data[key]._keys.push(i);
+
+                    this.emit(path + '.' + i + ':set', value[i], null, remote);
+                    this.emit('*:set', path + '.' + i, value[i], null, remote);
+
+                    this.silenceRestore(state);
                 }
-            } else if (! obj._equals(node._data[key]._data[keys[i]], value[keys[i]])) {
-                if (typeof(value[keys[i]]) === 'object') {
-                    c = obj.set(node._data[key]._path + '.' + keys[i], value[keys[i]], true);
-                    if (c) changed = true;
-                } else if (node._data[key]._data[keys[i]] !== value[keys[i]]) {
-                    changed = true;
+            }
 
-                    if (node._data[key]._keys.indexOf(keys[i]) === -1)
-                        node._data[key]._keys.push(keys[i]);
+            if (silent)
+                state = this.silence();
 
-                    node._data[key]._data[keys[i]] = value[keys[i]];
+            // passing undefined as valueOld here
+            // but we should get the old value to be consistent
+            this.emit(path + ':set', value, undefined, remote);
+            this.emit('*:set', path, value, undefined, remote);
 
-                    state = obj.silence();
-                    obj.emit(node._data[key]._path + '.' + keys[i] + ':set', node._data[key]._data[keys[i]], null, remote);
-                    obj.emit('*:set', node._data[key]._path + '.' + keys[i], node._data[key]._data[keys[i]], null, remote);
-                    obj.silenceRestore(state);
+            if (silent)
+                this.silenceRestore(state);
+        } else {
+            if (silent)
+                state = this.silence();
+
+            target._data[key] = value;
+
+            this.emit(path + ':set', value, undefined, remote);
+            this.emit('*:set', path, value, undefined, remote);
+
+            if (silent)
+                this.silenceRestore(state);
+        }
+
+        return true;
+    }
+
+    set(path, value, silent, remote, force) {
+        var i;
+        var valueOld;
+        var keys = Observer._splitPath(path);
+        var length = keys.length;
+        var key = keys[length - 1];
+        var node = this;
+        var nodePath = '';
+        var obj = this;
+        var state;
+
+        for (i = 0; i < length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[keys[i]];
+
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
                 }
+            } else {
+                if (i < length && typeof(node._data[keys[i]]) !== 'object') {
+                    if (node._data[keys[i]])
+                        obj.unset((node.__path ? node.__path + '.' : '') + keys[i]);
+
+                    node._data[keys[i]] = {
+                        _path: path,
+                        _keys: [],
+                        _data: { }
+                    };
+                    node._keys.push(keys[i]);
+                }
+
+                if (i === length - 1 && node.__path)
+                    nodePath = node.__path + '.' + keys[i];
+
+                node = node._data[keys[i]];
             }
         }
 
-        if (changed) {
+        if (node instanceof Array) {
+            var ind = parseInt(key, 10);
+            if (node[ind] === value && !force)
+                return;
+
+            valueOld = node[ind];
+            if (valueOld instanceof Observer) {
+                valueOld = valueOld.json();
+            } else {
+                valueOld = obj.json(valueOld);
+            }
+
+            node[ind] = value;
+
+            if (value instanceof Observer) {
+                value._parent = obj;
+                value._parentPath = nodePath;
+                value._parentField = node;
+                value._parentKey = null;
+            }
+
             if (silent)
                 state = obj.silence();
 
-            var val = obj.json(node._data[key]);
+            obj.emit(path + ':set', value, valueOld, remote);
+            obj.emit('*:set', path, value, valueOld, remote);
 
-            obj.emit(node._data[key]._path + ':set', val, valueOld, remote);
-            obj.emit('*:set', node._data[key]._path, val, valueOld, remote);
+            if (silent)
+                obj.silenceRestore(state);
+
+            return true;
+        } else if (node._data && ! node._data.hasOwnProperty(key)) {
+            if (typeof(value) === 'object') {
+                return obj._prepare(node, key, value, false, remote);
+            }
+            node._data[key] = value;
+            node._keys.push(key);
+
+            if (silent)
+                state = obj.silence();
+
+            obj.emit(path + ':set', value, null, remote);
+            obj.emit('*:set', path, value, null, remote);
 
             if (silent)
                 obj.silenceRestore(state);
 
             return true;
         }
-        return false;
-    }
 
-    var data;
-    if (! node.hasOwnProperty('_data') && node.hasOwnProperty(key)) {
-        data = node;
-    } else {
-        data = node._data;
-    }
+        if (typeof(value) === 'object' && (value instanceof Array)) {
+            if (value.equals(node._data[key]) && !force)
+                return false;
 
-    if (data[key] === value && !force)
-        return false;
+            valueOld = node._data[key];
+            if (! (valueOld instanceof Observer))
+                valueOld = obj.json(valueOld);
 
-    if (silent)
-        state = obj.silence();
+            if (node._data[key] && node._data[key].length === value.length) {
+                state = obj.silence();
 
-    valueOld = data[key];
-    if (! (valueOld instanceof Observer))
-        valueOld = obj.json(valueOld);
+                    // handle new array instance
+                if (value.length === 0) {
+                    node._data[key] = value;
+                }
 
-    data[key] = value;
+                for (i = 0; i < node._data[key].length; i++) {
+                    if (node._data[key][i] instanceof Observer) {
+                        node._data[key][i].patch(value[i], true);
+                    } else if (node._data[key][i] !== value[i]) {
+                        node._data[key][i] = value[i];
+                        obj.emit(path + '.' + i + ':set', node._data[key][i], valueOld && valueOld[i] || null, remote);
+                        obj.emit('*:set', path + '.' + i, node._data[key][i], valueOld && valueOld[i] || null, remote);
+                    }
+                }
 
-    obj.emit(path + ':set', value, valueOld, remote);
-    obj.emit('*:set', path, value, valueOld, remote);
+                obj.silenceRestore(state);
+            } else {
+                node._data[key] = [];
+                value.forEach((val) => {
+                    this._doInsert(node, key, val, undefined, true);
+                });
 
-    if (silent)
-        obj.silenceRestore(state);
+                state = obj.silence();
 
-    return true;
-};
+                for (i = 0; i < node._data[key].length; i++) {
+                    obj.emit(path + '.' + i + ':set', node._data[key][i], valueOld && valueOld[i] || null, remote);
+                    obj.emit('*:set', path + '.' + i, node._data[key][i], valueOld && valueOld[i] || null, remote);
+                }
+                obj.silenceRestore(state);
+            }
 
+            if (silent)
+                state = obj.silence();
 
-Observer.prototype.has = function (path) {
-    var keys = Observer._splitPath(path);
-    var node = this;
-    for (var i = 0, len = keys.length; i < len; i++) {
-        if (node == undefined)
-            return undefined;
+            obj.emit(path + ':set', value, valueOld, remote);
+            obj.emit('*:set', path, value, valueOld, remote);
 
-        if (node._data) {
-            node = node._data[keys[i]];
-        } else {
-            node = node[keys[i]];
+            if (silent)
+                obj.silenceRestore(state);
+
+            return true;
+        } else if (typeof(value) === 'object' && (value instanceof Object)) {
+            var changed = false;
+            valueOld = node._data[key];
+            if (! (valueOld instanceof Observer))
+                valueOld = obj.json(valueOld);
+
+            keys = Object.keys(value);
+
+            if (! node._data[key] || ! node._data[key]._data) {
+                if (node._data[key]) {
+                    obj.unset((node.__path ? node.__path + '.' : '') + key);
+                } else {
+                    changed = true;
+                }
+
+                node._data[key] = {
+                    _path: path,
+                    _keys: [],
+                    _data: { }
+                };
+            }
+
+            var c;
+
+            for (var n in node._data[key]._data) {
+                if (! value.hasOwnProperty(n)) {
+                    c = obj.unset(path + '.' + n, true);
+                    if (c) changed = true;
+                } else if (node._data[key]._data.hasOwnProperty(n)) {
+                    if (! obj._equals(node._data[key]._data[n], value[n])) {
+                        c = obj.set(path + '.' + n, value[n], true);
+                        if (c) changed = true;
+                    }
+                } else {
+                    c = obj._prepare(node._data[key], n, value[n], true, remote);
+                    if (c) changed = true;
+                }
+            }
+
+            for (i = 0; i < keys.length; i++) {
+                if (value[keys[i]] === undefined && node._data[key]._data.hasOwnProperty(keys[i])) {
+                    c = obj.unset(path + '.' + keys[i], true);
+                    if (c) changed = true;
+                } else if (typeof(value[keys[i]]) === 'object') {
+                    if (node._data[key]._data.hasOwnProperty(keys[i])) {
+                        c = obj.set(path + '.' + keys[i], value[keys[i]], true);
+                        if (c) changed = true;
+                    } else {
+                        c = obj._prepare(node._data[key], keys[i], value[keys[i]], true, remote);
+                        if (c) changed = true;
+                    }
+                } else if (! obj._equals(node._data[key]._data[keys[i]], value[keys[i]])) {
+                    if (typeof(value[keys[i]]) === 'object') {
+                        c = obj.set(node._data[key]._path + '.' + keys[i], value[keys[i]], true);
+                        if (c) changed = true;
+                    } else if (node._data[key]._data[keys[i]] !== value[keys[i]]) {
+                        changed = true;
+
+                        if (node._data[key]._keys.indexOf(keys[i]) === -1)
+                            node._data[key]._keys.push(keys[i]);
+
+                        node._data[key]._data[keys[i]] = value[keys[i]];
+
+                        state = obj.silence();
+                        obj.emit(node._data[key]._path + '.' + keys[i] + ':set', node._data[key]._data[keys[i]], null, remote);
+                        obj.emit('*:set', node._data[key]._path + '.' + keys[i], node._data[key]._data[keys[i]], null, remote);
+                        obj.silenceRestore(state);
+                    }
+                }
+            }
+
+            if (changed) {
+                if (silent)
+                    state = obj.silence();
+
+                var val = obj.json(node._data[key]);
+
+                obj.emit(node._data[key]._path + ':set', val, valueOld, remote);
+                obj.emit('*:set', node._data[key]._path, val, valueOld, remote);
+
+                if (silent)
+                    obj.silenceRestore(state);
+
+                return true;
+            }
+            return false;
         }
-    }
 
-    return node !== undefined;
-};
-
-
-Observer.prototype.get = function (path, raw) {
-    var keys = Observer._splitPath(path);
-    var node = this;
-    for (var i = 0; i < keys.length; i++) {
-        if (node == undefined)
-            return undefined;
-
-        if (node._data) {
-            node = node._data[keys[i]];
+        var data;
+        if (! node.hasOwnProperty('_data') && node.hasOwnProperty(key)) {
+            data = node;
         } else {
-            node = node[keys[i]];
+            data = node._data;
         }
-    }
 
-    if (raw)
-        return node;
+        if (data[key] === value && !force)
+            return false;
 
-    if (node == null) {
-        return null;
-    }
-    return this.json(node);
+        if (silent)
+            state = obj.silence();
 
-};
+        valueOld = data[key];
+        if (! (valueOld instanceof Observer))
+            valueOld = obj.json(valueOld);
 
+        data[key] = value;
 
-Observer.prototype.getRaw = function (path) {
-    return this.get(path, true);
-};
+        obj.emit(path + ':set', value, valueOld, remote);
+        obj.emit('*:set', path, value, valueOld, remote);
 
+        if (silent)
+            obj.silenceRestore(state);
 
-Observer.prototype._equals = function (a, b) {
-    if (a === b) {
         return true;
-    } else if (a instanceof Array && b instanceof Array && a.equals(b)) {
-        return true;
     }
-    return false;
 
-};
+    has(path) {
+        var keys = Observer._splitPath(path);
+        var node = this;
+        for (var i = 0, len = keys.length; i < len; i++) {
+            if (node == undefined)
+                return undefined;
 
-
-Observer.prototype.unset = function (path, silent, remote) {
-    var i;
-    var keys = Observer._splitPath(path);
-    var key = keys[keys.length - 1];
-    var node = this;
-    var obj = this;
-
-    for (i = 0; i < keys.length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[keys[i]];
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
-                obj = node;
+            if (node._data) {
+                node = node._data[keys[i]];
+            } else {
+                node = node[keys[i]];
             }
-        } else {
-            node = node._data[keys[i]];
         }
+
+        return node !== undefined;
     }
 
-    if (! node._data || ! node._data.hasOwnProperty(key))
+    get(path, raw) {
+        var keys = Observer._splitPath(path);
+        var node = this;
+        for (var i = 0; i < keys.length; i++) {
+            if (node == undefined)
+                return undefined;
+
+            if (node._data) {
+                node = node._data[keys[i]];
+            } else {
+                node = node[keys[i]];
+            }
+        }
+
+        if (raw)
+            return node;
+
+        if (node == null) {
+            return null;
+        }
+        return this.json(node);
+
+    }
+
+    getRaw(path) {
+        return this.get(path, true);
+    }
+
+    _equals(a, b) {
+        if (a === b) {
+            return true;
+        } else if (a instanceof Array && b instanceof Array && a.equals(b)) {
+            return true;
+        }
         return false;
 
-    var valueOld = node._data[key];
-    if (! (valueOld instanceof Observer))
-        valueOld = obj.json(valueOld);
+    }
 
-    // recursive
-    if (node._data[key] && node._data[key]._data) {
-        // do this in reverse order because node._data[key]._keys gets
-        // modified as we loop
-        for (i = node._data[key]._keys.length - 1; i >= 0; i--) {
-            obj.unset(path + '.' + node._data[key]._keys[i], true);
+    unset(path, silent, remote) {
+        var i;
+        var keys = Observer._splitPath(path);
+        var key = keys[keys.length - 1];
+        var node = this;
+        var obj = this;
+
+        for (i = 0; i < keys.length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[keys[i]];
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
+                }
+            } else {
+                node = node._data[keys[i]];
+            }
+        }
+
+        if (! node._data || ! node._data.hasOwnProperty(key))
+            return false;
+
+        var valueOld = node._data[key];
+        if (! (valueOld instanceof Observer))
+            valueOld = obj.json(valueOld);
+
+        // recursive
+        if (node._data[key] && node._data[key]._data) {
+            // do this in reverse order because node._data[key]._keys gets
+            // modified as we loop
+            for (i = node._data[key]._keys.length - 1; i >= 0; i--) {
+                obj.unset(path + '.' + node._data[key]._keys[i], true);
+            }
+        }
+
+        node._keys.splice(node._keys.indexOf(key), 1);
+        delete node._data[key];
+
+        var state;
+        if (silent)
+            state = obj.silence();
+
+        obj.emit(path + ':unset', valueOld, remote);
+        obj.emit('*:unset', path, valueOld, remote);
+
+        if (silent)
+            obj.silenceRestore(state);
+
+        return true;
+    }
+
+    remove(path, ind, silent, remote) {
+        var keys = Observer._splitPath(path);
+        var key = keys[keys.length - 1];
+        var node = this;
+        var obj = this;
+
+        for (var i = 0; i < keys.length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[parseInt(keys[i], 10)];
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
+                }
+            } else if (node._data && node._data.hasOwnProperty(keys[i])) {
+                node = node._data[keys[i]];
+            } else {
+                return;
+            }
+        }
+
+        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+            return;
+
+        var arr = node._data[key];
+        if (arr.length < ind)
+            return;
+
+        var value = arr[ind];
+        if (value instanceof Observer) {
+            value._parent = null;
+        } else {
+            value = obj.json(value);
+        }
+
+        arr.splice(ind, 1);
+
+        var state;
+        if (silent)
+            state = obj.silence();
+
+        obj.emit(path + ':remove', value, ind, remote);
+        obj.emit('*:remove', path, value, ind, remote);
+
+        if (silent)
+            obj.silenceRestore(state);
+
+        return true;
+    }
+
+    removeValue(path, value, silent, remote) {
+        var keys = Observer._splitPath(path);
+        var key = keys[keys.length - 1];
+        var node = this;
+        var obj = this;
+
+        for (var i = 0; i < keys.length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[parseInt(keys[i], 10)];
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
+                }
+            } else if (node._data && node._data.hasOwnProperty(keys[i])) {
+                node = node._data[keys[i]];
+            } else {
+                return;
+            }
+        }
+
+        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+            return;
+
+        var arr = node._data[key];
+
+        var ind = arr.indexOf(value);
+        if (ind === -1) {
+            return;
+        }
+
+        if (arr.length < ind)
+            return;
+
+        value = arr[ind];
+        if (value instanceof Observer) {
+            value._parent = null;
+        } else {
+            value = obj.json(value);
+        }
+
+        arr.splice(ind, 1);
+
+        var state;
+        if (silent)
+            state = obj.silence();
+
+        obj.emit(path + ':remove', value, ind, remote);
+        obj.emit('*:remove', path, value, ind, remote);
+
+        if (silent)
+            obj.silenceRestore(state);
+
+        return true;
+    }
+
+    insert(path, value, ind, silent, remote) {
+        var keys = Observer._splitPath(path);
+        var key = keys[keys.length - 1];
+        var node = this;
+        var obj = this;
+
+        for (var i = 0; i < keys.length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[parseInt(keys[i], 10)];
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
+                }
+            } else if (node._data && node._data.hasOwnProperty(keys[i])) {
+                node = node._data[keys[i]];
+            } else {
+                return;
+            }
+        }
+
+        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+            return;
+
+        var arr = node._data[key];
+
+        value = obj._doInsert(node, key, value, ind);
+
+        if (ind === undefined) {
+            ind = arr.length - 1;
+        }
+
+        var state;
+        if (silent)
+            state = obj.silence();
+
+        obj.emit(path + ':insert', value, ind, remote);
+        obj.emit('*:insert', path, value, ind, remote);
+
+        if (silent)
+            obj.silenceRestore(state);
+
+        return true;
+    }
+
+    _doInsert(node, key, value, ind, allowDuplicates) {
+        const arr = node._data[key];
+
+        if (typeof(value) === 'object' && ! (value instanceof Observer) && value !== null) {
+            if (value instanceof Array) {
+                value = value.slice(0);
+            } else {
+                value = new Observer(value);
+            }
+        }
+
+        const path = node._path ? `${node._path}.${key}` : key;
+        if (value !== null && !allowDuplicates && (!this._pathsWithDuplicates || !this._pathsWithDuplicates[path])) {
+            if (arr.indexOf(value) !== -1) {
+                return;
+            }
+        }
+
+        if (ind === undefined) {
+            arr.push(value);
+        } else {
+            arr.splice(ind, 0, value);
+        }
+
+        if (value instanceof Observer) {
+            value._parent = this;
+            value._parentPath = path;
+            value._parentField = arr;
+            value._parentKey = null;
+        } else {
+            value = this.json(value);
+        }
+
+        return value;
+    }
+
+    move(path, indOld, indNew, silent, remote) {
+        var keys = Observer._splitPath(path);
+        var key = keys[keys.length - 1];
+        var node = this;
+        var obj = this;
+
+        for (var i = 0; i < keys.length - 1; i++) {
+            if (node instanceof Array) {
+                node = node[parseInt(keys[i], 10)];
+                if (node instanceof Observer) {
+                    path = keys.slice(i + 1).join('.');
+                    obj = node;
+                }
+            } else if (node._data && node._data.hasOwnProperty(keys[i])) {
+                node = node._data[keys[i]];
+            } else {
+                return;
+            }
+        }
+
+        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+            return;
+
+        var arr = node._data[key];
+
+        if (arr.length < indOld || arr.length < indNew || indOld === indNew)
+            return;
+
+        var value = arr[indOld];
+
+        arr.splice(indOld, 1);
+
+        if (indNew === -1)
+            indNew = arr.length;
+
+        arr.splice(indNew, 0, value);
+
+        if (! (value instanceof Observer))
+            value = obj.json(value);
+
+        var state;
+        if (silent)
+            state = obj.silence();
+
+        obj.emit(path + ':move', value, indNew, indOld, remote);
+        obj.emit('*:move', path, value, indNew, indOld, remote);
+
+        if (silent)
+            obj.silenceRestore(state);
+
+        return true;
+    }
+
+    patch(data, removeMIssingKeys) {
+        var key;
+
+        if (typeof(data) !== 'object')
+            return;
+
+        for (key in data) {
+            if (typeof(data[key]) === 'object' && ! this._data.hasOwnProperty(key)) {
+                this._prepare(this, key, data[key]);
+            } else if (this._data[key] !== data[key]) {
+                this.set(key, data[key]);
+            }
+        }
+
+        if (removeMIssingKeys) {
+            for (key in this._data) {
+                if (!data.hasOwnProperty(key)) {
+                    this.unset(key);
+                }
+            }
         }
     }
 
-    node._keys.splice(node._keys.indexOf(key), 1);
-    delete node._data[key];
+    json(target) {
+        var key, n;
+        var obj = { };
+        var node = target === undefined ? this : target;
+        var len, nlen;
 
-    var state;
-    if (silent)
-        state = obj.silence();
+        if (node instanceof Object && node._keys) {
+            len = node._keys.length;
+            for (var i = 0; i < len; i++) {
+                key = node._keys[i];
+                var value = node._data[key];
+                var type = typeof(value);
 
-    obj.emit(path + ':unset', valueOld, remote);
-    obj.emit('*:unset', path, valueOld, remote);
+                if (type === 'object' && (value instanceof Array)) {
+                    obj[key] = value.slice(0);
 
-    if (silent)
-        obj.silenceRestore(state);
+                    nlen = obj[key].length;
+                    for (n = 0; n < nlen; n++) {
+                        if (typeof(obj[key][n]) === 'object')
+                            obj[key][n] = this.json(obj[key][n]);
+                    }
+                } else if (type === 'object' && (value instanceof Object)) {
+                    obj[key] = this.json(value);
+                } else {
+                    obj[key] = value;
+                }
+            }
+        } else {
+            if (node === null) {
+                return null;
+            } else if (typeof(node) === 'object' && (node instanceof Array)) {
+                obj = node.slice(0);
 
-    return true;
-};
-
-
-Observer.prototype.remove = function (path, ind, silent, remote) {
-    var keys = Observer._splitPath(path);
-    var key = keys[keys.length - 1];
-    var node = this;
-    var obj = this;
-
-    for (var i = 0; i < keys.length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[parseInt(keys[i], 10)];
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
+                len = obj.length;
+                for (n = 0; n < len; n++) {
+                    obj[n] = this.json(obj[n]);
+                }
+            } else if (typeof(node) === 'object') {
+                for (key in node) {
+                    if (node.hasOwnProperty(key))
+                        obj[key] = node[key];
+                }
+            } else {
                 obj = node;
             }
-        } else if (node._data && node._data.hasOwnProperty(keys[i])) {
-            node = node._data[keys[i]];
-        } else {
-            return;
         }
+        return obj;
     }
 
-    if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
-        return;
+    forEach(fn, target, path) {
+        var node = target || this;
+        path = path || '';
 
-    var arr = node._data[key];
-    if (arr.length < ind)
-        return;
-
-    var value = arr[ind];
-    if (value instanceof Observer) {
-        value._parent = null;
-    } else {
-        value = obj.json(value);
-    }
-
-    arr.splice(ind, 1);
-
-    var state;
-    if (silent)
-        state = obj.silence();
-
-    obj.emit(path + ':remove', value, ind, remote);
-    obj.emit('*:remove', path, value, ind, remote);
-
-    if (silent)
-        obj.silenceRestore(state);
-
-    return true;
-};
-
-
-Observer.prototype.removeValue = function (path, value, silent, remote) {
-    var keys = Observer._splitPath(path);
-    var key = keys[keys.length - 1];
-    var node = this;
-    var obj = this;
-
-    for (var i = 0; i < keys.length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[parseInt(keys[i], 10)];
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
-                obj = node;
-            }
-        } else if (node._data && node._data.hasOwnProperty(keys[i])) {
-            node = node._data[keys[i]];
-        } else {
-            return;
-        }
-    }
-
-    if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
-        return;
-
-    var arr = node._data[key];
-
-    var ind = arr.indexOf(value);
-    if (ind === -1) {
-        return;
-    }
-
-    if (arr.length < ind)
-        return;
-
-    value = arr[ind];
-    if (value instanceof Observer) {
-        value._parent = null;
-    } else {
-        value = obj.json(value);
-    }
-
-    arr.splice(ind, 1);
-
-    var state;
-    if (silent)
-        state = obj.silence();
-
-    obj.emit(path + ':remove', value, ind, remote);
-    obj.emit('*:remove', path, value, ind, remote);
-
-    if (silent)
-        obj.silenceRestore(state);
-
-    return true;
-};
-
-
-Observer.prototype.insert = function (path, value, ind, silent, remote) {
-    var keys = Observer._splitPath(path);
-    var key = keys[keys.length - 1];
-    var node = this;
-    var obj = this;
-
-    for (var i = 0; i < keys.length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[parseInt(keys[i], 10)];
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
-                obj = node;
-            }
-        } else if (node._data && node._data.hasOwnProperty(keys[i])) {
-            node = node._data[keys[i]];
-        } else {
-            return;
-        }
-    }
-
-    if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
-        return;
-
-    var arr = node._data[key];
-
-    value = obj._doInsert(node, key, value, ind);
-
-    if (ind === undefined) {
-        ind = arr.length - 1;
-    }
-
-    var state;
-    if (silent)
-        state = obj.silence();
-
-    obj.emit(path + ':insert', value, ind, remote);
-    obj.emit('*:insert', path, value, ind, remote);
-
-    if (silent)
-        obj.silenceRestore(state);
-
-    return true;
-};
-
-Observer.prototype._doInsert = function (node, key, value, ind, allowDuplicates) {
-    const arr = node._data[key];
-
-    if (typeof(value) === 'object' && ! (value instanceof Observer) && value !== null) {
-        if (value instanceof Array) {
-            value = value.slice(0);
-        } else {
-            value = new Observer(value);
-        }
-    }
-
-    const path = node._path ? `${node._path}.${key}` : key;
-    if (value !== null && !allowDuplicates && (!this._pathsWithDuplicates || !this._pathsWithDuplicates[path])) {
-        if (arr.indexOf(value) !== -1) {
-            return;
-        }
-    }
-
-
-    if (ind === undefined) {
-        arr.push(value);
-    } else {
-        arr.splice(ind, 0, value);
-    }
-
-    if (value instanceof Observer) {
-        value._parent = this;
-        value._parentPath = path;
-        value._parentField = arr;
-        value._parentKey = null;
-    } else {
-        value = this.json(value);
-    }
-
-    return value;
-};
-
-Observer.prototype.move = function (path, indOld, indNew, silent, remote) {
-    var keys = Observer._splitPath(path);
-    var key = keys[keys.length - 1];
-    var node = this;
-    var obj = this;
-
-    for (var i = 0; i < keys.length - 1; i++) {
-        if (node instanceof Array) {
-            node = node[parseInt(keys[i], 10)];
-            if (node instanceof Observer) {
-                path = keys.slice(i + 1).join('.');
-                obj = node;
-            }
-        } else if (node._data && node._data.hasOwnProperty(keys[i])) {
-            node = node._data[keys[i]];
-        } else {
-            return;
-        }
-    }
-
-    if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
-        return;
-
-    var arr = node._data[key];
-
-    if (arr.length < indOld || arr.length < indNew || indOld === indNew)
-        return;
-
-    var value = arr[indOld];
-
-    arr.splice(indOld, 1);
-
-    if (indNew === -1)
-        indNew = arr.length;
-
-    arr.splice(indNew, 0, value);
-
-    if (! (value instanceof Observer))
-        value = obj.json(value);
-
-    var state;
-    if (silent)
-        state = obj.silence();
-
-    obj.emit(path + ':move', value, indNew, indOld, remote);
-    obj.emit('*:move', path, value, indNew, indOld, remote);
-
-    if (silent)
-        obj.silenceRestore(state);
-
-    return true;
-};
-
-
-Observer.prototype.patch = function (data, removeMIssingKeys) {
-    var key;
-
-    if (typeof(data) !== 'object')
-        return;
-
-    for (key in data) {
-        if (typeof(data[key]) === 'object' && ! this._data.hasOwnProperty(key)) {
-            this._prepare(this, key, data[key]);
-        } else if (this._data[key] !== data[key]) {
-            this.set(key, data[key]);
-        }
-    }
-
-    if (removeMIssingKeys) {
-        for (key in this._data) {
-            if (!data.hasOwnProperty(key)) {
-                this.unset(key);
-            }
-        }
-    }
-};
-
-
-Observer.prototype.json = function (target) {
-    var key, n;
-    var obj = { };
-    var node = target === undefined ? this : target;
-    var len, nlen;
-
-    if (node instanceof Object && node._keys) {
-        len = node._keys.length;
-        for (var i = 0; i < len; i++) {
-            key = node._keys[i];
+        for (var i = 0; i < node._keys.length; i++) {
+            var key = node._keys[i];
             var value = node._data[key];
-            var type = typeof(value);
+            var type = (this.schema && this.schema.has(path + key) && this.schema.get(path + key).type.name.toLowerCase()) || typeof(value);
 
             if (type === 'object' && (value instanceof Array)) {
-                obj[key] = value.slice(0);
-
-                nlen = obj[key].length;
-                for (n = 0; n < nlen; n++) {
-                    if (typeof(obj[key][n]) === 'object')
-                        obj[key][n] = this.json(obj[key][n]);
-                }
+                fn(path + key, 'array', value, key);
             } else if (type === 'object' && (value instanceof Object)) {
-                obj[key] = this.json(value);
+                fn(path + key, 'object', value, key);
+                this.forEach(fn, value, path + key + '.');
             } else {
-                obj[key] = value;
+                fn(path + key, type, value, key);
             }
-        }
-    } else {
-        if (node === null) {
-            return null;
-        } else if (typeof(node) === 'object' && (node instanceof Array)) {
-            obj = node.slice(0);
-
-            len = obj.length;
-            for (n = 0; n < len; n++) {
-                obj[n] = this.json(obj[n]);
-            }
-        } else if (typeof(node) === 'object') {
-            for (key in node) {
-                if (node.hasOwnProperty(key))
-                    obj[key] = node[key];
-            }
-        } else {
-            obj = node;
         }
     }
-    return obj;
-};
 
-
-Observer.prototype.forEach = function (fn, target, path) {
-    var node = target || this;
-    path = path || '';
-
-    for (var i = 0; i < node._keys.length; i++) {
-        var key = node._keys[i];
-        var value = node._data[key];
-        var type = (this.schema && this.schema.has(path + key) && this.schema.get(path + key).type.name.toLowerCase()) || typeof(value);
-
-        if (type === 'object' && (value instanceof Array)) {
-            fn(path + key, 'array', value, key);
-        } else if (type === 'object' && (value instanceof Object)) {
-            fn(path + key, 'object', value, key);
-            this.forEach(fn, value, path + key + '.');
-        } else {
-            fn(path + key, type, value, key);
-        }
+    /**
+     * Returns the latest observer instance. This is important when
+     * dealing with undo / redo where the observer might have been deleted
+     * and/or possibly re-created.
+     *
+     * @returns {Observer} The latest instance of the observer.
+     */
+    latest() {
+        return this._latestFn ? this._latestFn() : this;
     }
-};
 
-/**
- * Returns the latest observer instance. This is important when
- * dealing with undo / redo where the observer might have been deleted
- * and/or possibly re-created.
- *
- * @returns {Observer} The latest instance of the observer.
- */
-Observer.prototype.latest = function () {
-    return this._latestFn ? this._latestFn() : this;
-};
+    destroy() {
+        if (this._destroyed) return;
+        this._destroyed = true;
+        this.emit('destroy');
+        this.unbind();
+    }
 
-Observer.prototype.destroy = function () {
-    if (this._destroyed) return;
-    this._destroyed = true;
-    this.emit('destroy');
-    this.unbind();
-};
-
-Object.defineProperty(Observer.prototype, 'latestFn', {
-    get: function () {
+    get latestFn() {
         return this._latestFn;
-    },
-    set: function (value) {
+    }
+
+    set latestFn(value) {
         this._latestFn = value;
     }
-});
+}
 
 export default Observer;

--- a/src/observer.js
+++ b/src/observer.js
@@ -21,7 +21,7 @@ class Observer extends Events {
         this._pathsWithDuplicates = null;
         if (options.pathsWithDuplicates) {
             this._pathsWithDuplicates = {};
-            for (var i = 0; i < options.pathsWithDuplicates.length; i++) {
+            for (let i = 0; i < options.pathsWithDuplicates.length; i++) {
                 this._pathsWithDuplicates[options.pathsWithDuplicates[i]] = true;
             }
         }
@@ -37,13 +37,13 @@ class Observer extends Events {
 
         this._silent = false;
 
-        var propagate = function (evt) {
+        const propagate = function (evt) {
             return function (path, arg1, arg2, arg3) {
-                if (! this._parent)
+                if (!this._parent)
                     return;
 
-                var key = this._parentKey;
-                if (! key && (this._parentField instanceof Array)) {
+                let key = this._parentKey;
+                if (!key && (this._parentField instanceof Array)) {
                     key = this._parentField.indexOf(this);
 
                     if (key === -1)
@@ -52,7 +52,7 @@ class Observer extends Events {
 
                 path = this._parentPath + '.' + key + '.' + path;
 
-                var state;
+                let state;
                 if (this._silent)
                     state = this._parent.silence();
 
@@ -78,8 +78,8 @@ class Observer extends Events {
     static _splitPathsCache = {};
 
     static _splitPath(path) {
-        var cache = Observer._splitPathsCache;
-        var result = cache[path];
+        const cache = Observer._splitPathsCache;
+        let result = cache[path];
         if (!result) {
             result = path.split('.');
             cache[path] = result;
@@ -94,12 +94,12 @@ class Observer extends Events {
         this._silent = true;
 
         // history hook to prevent array values to be recorded
-        var historyState = this.history && this.history.enabled;
+        const historyState = this.history && this.history.enabled;
         if (historyState)
             this.history.enabled = false;
 
         // sync hook to prevent array values to be recorded as array root already did
-        var syncState = this.sync && this.sync.enabled;
+        const syncState = this.sync && this.sync.enabled;
         if (syncState)
             this.sync.enabled = false;
 
@@ -117,10 +117,10 @@ class Observer extends Events {
     }
 
     _prepare(target, key, value, silent, remote) {
-        var i;
-        var state;
-        var path = (target._path ? (target._path + '.') : '') + key;
-        var type = typeof(value);
+        let i;
+        let state;
+        const path = (target._path ? (target._path + '.') : '') + key;
+        const type = typeof value;
 
         target._keys.push(key);
 
@@ -128,7 +128,7 @@ class Observer extends Events {
             target._data[key] = value.slice(0);
 
             for (i = 0; i < target._data[key].length; i++) {
-                if (typeof(target._data[key][i]) === 'object' && target._data[key][i] !== null) {
+                if (typeof target._data[key][i] === 'object' && target._data[key][i] !== null) {
                     if (target._data[key][i] instanceof Array) {
                         target._data[key][i].slice(0);
                     } else {
@@ -156,7 +156,7 @@ class Observer extends Events {
             if (silent)
                 this.silenceRestore(state);
         } else if (type === 'object' && (value instanceof Object)) {
-            if (typeof(target._data[key]) !== 'object') {
+            if (typeof target._data[key] !== 'object') {
                 target._data[key] = {
                     _path: path,
                     _keys: [],
@@ -165,7 +165,7 @@ class Observer extends Events {
             }
 
             for (i in value) {
-                if (typeof(value[i]) === 'object') {
+                if (typeof value[i] === 'object') {
                     this._prepare(target._data[key], i, value[i], true, remote);
                 } else {
                     state = this.silence();
@@ -207,15 +207,15 @@ class Observer extends Events {
     }
 
     set(path, value, silent, remote, force) {
-        var i;
-        var valueOld;
-        var keys = Observer._splitPath(path);
-        var length = keys.length;
-        var key = keys[length - 1];
-        var node = this;
-        var nodePath = '';
-        var obj = this;
-        var state;
+        let i;
+        let valueOld;
+        let keys = Observer._splitPath(path);
+        const length = keys.length;
+        const key = keys[length - 1];
+        let node = this;
+        let nodePath = '';
+        let obj = this;
+        let state;
 
         for (i = 0; i < length - 1; i++) {
             if (node instanceof Array) {
@@ -226,7 +226,7 @@ class Observer extends Events {
                     obj = node;
                 }
             } else {
-                if (i < length && typeof(node._data[keys[i]]) !== 'object') {
+                if (i < length && typeof node._data[keys[i]] !== 'object') {
                     if (node._data[keys[i]])
                         obj.unset((node.__path ? node.__path + '.' : '') + keys[i]);
 
@@ -246,7 +246,7 @@ class Observer extends Events {
         }
 
         if (node instanceof Array) {
-            var ind = parseInt(key, 10);
+            const ind = parseInt(key, 10);
             if (node[ind] === value && !force)
                 return;
 
@@ -276,8 +276,8 @@ class Observer extends Events {
                 obj.silenceRestore(state);
 
             return true;
-        } else if (node._data && ! node._data.hasOwnProperty(key)) {
-            if (typeof(value) === 'object') {
+        } else if (node._data && !node._data.hasOwnProperty(key)) {
+            if (typeof value === 'object') {
                 return obj._prepare(node, key, value, false, remote);
             }
             node._data[key] = value;
@@ -295,12 +295,12 @@ class Observer extends Events {
             return true;
         }
 
-        if (typeof(value) === 'object' && (value instanceof Array)) {
+        if (typeof value === 'object' && (value instanceof Array)) {
             if (value.equals(node._data[key]) && !force)
                 return false;
 
             valueOld = node._data[key];
-            if (! (valueOld instanceof Observer))
+            if (!(valueOld instanceof Observer))
                 valueOld = obj.json(valueOld);
 
             if (node._data[key] && node._data[key].length === value.length) {
@@ -347,15 +347,15 @@ class Observer extends Events {
                 obj.silenceRestore(state);
 
             return true;
-        } else if (typeof(value) === 'object' && (value instanceof Object)) {
-            var changed = false;
+        } else if (typeof value === 'object' && (value instanceof Object)) {
+            let changed = false;
             valueOld = node._data[key];
-            if (! (valueOld instanceof Observer))
+            if (!(valueOld instanceof Observer))
                 valueOld = obj.json(valueOld);
 
             keys = Object.keys(value);
 
-            if (! node._data[key] || ! node._data[key]._data) {
+            if (!node._data[key] || !node._data[key]._data) {
                 if (node._data[key]) {
                     obj.unset((node.__path ? node.__path + '.' : '') + key);
                 } else {
@@ -369,14 +369,14 @@ class Observer extends Events {
                 };
             }
 
-            var c;
+            let c;
 
-            for (var n in node._data[key]._data) {
-                if (! value.hasOwnProperty(n)) {
+            for (const n in node._data[key]._data) {
+                if (!value.hasOwnProperty(n)) {
                     c = obj.unset(path + '.' + n, true);
                     if (c) changed = true;
                 } else if (node._data[key]._data.hasOwnProperty(n)) {
-                    if (! obj._equals(node._data[key]._data[n], value[n])) {
+                    if (!obj._equals(node._data[key]._data[n], value[n])) {
                         c = obj.set(path + '.' + n, value[n], true);
                         if (c) changed = true;
                     }
@@ -390,7 +390,7 @@ class Observer extends Events {
                 if (value[keys[i]] === undefined && node._data[key]._data.hasOwnProperty(keys[i])) {
                     c = obj.unset(path + '.' + keys[i], true);
                     if (c) changed = true;
-                } else if (typeof(value[keys[i]]) === 'object') {
+                } else if (typeof value[keys[i]] === 'object') {
                     if (node._data[key]._data.hasOwnProperty(keys[i])) {
                         c = obj.set(path + '.' + keys[i], value[keys[i]], true);
                         if (c) changed = true;
@@ -398,8 +398,8 @@ class Observer extends Events {
                         c = obj._prepare(node._data[key], keys[i], value[keys[i]], true, remote);
                         if (c) changed = true;
                     }
-                } else if (! obj._equals(node._data[key]._data[keys[i]], value[keys[i]])) {
-                    if (typeof(value[keys[i]]) === 'object') {
+                } else if (!obj._equals(node._data[key]._data[keys[i]], value[keys[i]])) {
+                    if (typeof value[keys[i]] === 'object') {
                         c = obj.set(node._data[key]._path + '.' + keys[i], value[keys[i]], true);
                         if (c) changed = true;
                     } else if (node._data[key]._data[keys[i]] !== value[keys[i]]) {
@@ -422,7 +422,7 @@ class Observer extends Events {
                 if (silent)
                     state = obj.silence();
 
-                var val = obj.json(node._data[key]);
+                const val = obj.json(node._data[key]);
 
                 obj.emit(node._data[key]._path + ':set', val, valueOld, remote);
                 obj.emit('*:set', node._data[key]._path, val, valueOld, remote);
@@ -435,8 +435,8 @@ class Observer extends Events {
             return false;
         }
 
-        var data;
-        if (! node.hasOwnProperty('_data') && node.hasOwnProperty(key)) {
+        let data;
+        if (!node.hasOwnProperty('_data') && node.hasOwnProperty(key)) {
             data = node;
         } else {
             data = node._data;
@@ -449,7 +449,7 @@ class Observer extends Events {
             state = obj.silence();
 
         valueOld = data[key];
-        if (! (valueOld instanceof Observer))
+        if (!(valueOld instanceof Observer))
             valueOld = obj.json(valueOld);
 
         data[key] = value;
@@ -464,9 +464,9 @@ class Observer extends Events {
     }
 
     has(path) {
-        var keys = Observer._splitPath(path);
-        var node = this;
-        for (var i = 0, len = keys.length; i < len; i++) {
+        const keys = Observer._splitPath(path);
+        let node = this;
+        for (let i = 0, len = keys.length; i < len; i++) {
             if (node == undefined)
                 return undefined;
 
@@ -481,9 +481,9 @@ class Observer extends Events {
     }
 
     get(path, raw) {
-        var keys = Observer._splitPath(path);
-        var node = this;
-        for (var i = 0; i < keys.length; i++) {
+        const keys = Observer._splitPath(path);
+        let node = this;
+        for (let i = 0; i < keys.length; i++) {
             if (node == undefined)
                 return undefined;
 
@@ -519,11 +519,11 @@ class Observer extends Events {
     }
 
     unset(path, silent, remote) {
-        var i;
-        var keys = Observer._splitPath(path);
-        var key = keys[keys.length - 1];
-        var node = this;
-        var obj = this;
+        let i;
+        const keys = Observer._splitPath(path);
+        const key = keys[keys.length - 1];
+        let node = this;
+        let obj = this;
 
         for (i = 0; i < keys.length - 1; i++) {
             if (node instanceof Array) {
@@ -537,11 +537,11 @@ class Observer extends Events {
             }
         }
 
-        if (! node._data || ! node._data.hasOwnProperty(key))
+        if (!node._data || !node._data.hasOwnProperty(key))
             return false;
 
-        var valueOld = node._data[key];
-        if (! (valueOld instanceof Observer))
+        let valueOld = node._data[key];
+        if (!(valueOld instanceof Observer))
             valueOld = obj.json(valueOld);
 
         // recursive
@@ -556,7 +556,7 @@ class Observer extends Events {
         node._keys.splice(node._keys.indexOf(key), 1);
         delete node._data[key];
 
-        var state;
+        let state;
         if (silent)
             state = obj.silence();
 
@@ -570,12 +570,12 @@ class Observer extends Events {
     }
 
     remove(path, ind, silent, remote) {
-        var keys = Observer._splitPath(path);
-        var key = keys[keys.length - 1];
-        var node = this;
-        var obj = this;
+        const keys = Observer._splitPath(path);
+        const key = keys[keys.length - 1];
+        let node = this;
+        let obj = this;
 
-        for (var i = 0; i < keys.length - 1; i++) {
+        for (let i = 0; i < keys.length - 1; i++) {
             if (node instanceof Array) {
                 node = node[parseInt(keys[i], 10)];
                 if (node instanceof Observer) {
@@ -589,14 +589,14 @@ class Observer extends Events {
             }
         }
 
-        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+        if (!node._data || !node._data.hasOwnProperty(key) || !(node._data[key] instanceof Array))
             return;
 
-        var arr = node._data[key];
+        const arr = node._data[key];
         if (arr.length < ind)
             return;
 
-        var value = arr[ind];
+        let value = arr[ind];
         if (value instanceof Observer) {
             value._parent = null;
         } else {
@@ -605,7 +605,7 @@ class Observer extends Events {
 
         arr.splice(ind, 1);
 
-        var state;
+        let state;
         if (silent)
             state = obj.silence();
 
@@ -619,12 +619,12 @@ class Observer extends Events {
     }
 
     removeValue(path, value, silent, remote) {
-        var keys = Observer._splitPath(path);
-        var key = keys[keys.length - 1];
-        var node = this;
-        var obj = this;
+        const keys = Observer._splitPath(path);
+        const key = keys[keys.length - 1];
+        let node = this;
+        let obj = this;
 
-        for (var i = 0; i < keys.length - 1; i++) {
+        for (let i = 0; i < keys.length - 1; i++) {
             if (node instanceof Array) {
                 node = node[parseInt(keys[i], 10)];
                 if (node instanceof Observer) {
@@ -638,12 +638,12 @@ class Observer extends Events {
             }
         }
 
-        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+        if (!node._data || !node._data.hasOwnProperty(key) || !(node._data[key] instanceof Array))
             return;
 
-        var arr = node._data[key];
+        const arr = node._data[key];
 
-        var ind = arr.indexOf(value);
+        const ind = arr.indexOf(value);
         if (ind === -1) {
             return;
         }
@@ -660,7 +660,7 @@ class Observer extends Events {
 
         arr.splice(ind, 1);
 
-        var state;
+        let state;
         if (silent)
             state = obj.silence();
 
@@ -674,12 +674,12 @@ class Observer extends Events {
     }
 
     insert(path, value, ind, silent, remote) {
-        var keys = Observer._splitPath(path);
-        var key = keys[keys.length - 1];
-        var node = this;
-        var obj = this;
+        const keys = Observer._splitPath(path);
+        const key = keys[keys.length - 1];
+        let node = this;
+        let obj = this;
 
-        for (var i = 0; i < keys.length - 1; i++) {
+        for (let i = 0; i < keys.length - 1; i++) {
             if (node instanceof Array) {
                 node = node[parseInt(keys[i], 10)];
                 if (node instanceof Observer) {
@@ -693,10 +693,10 @@ class Observer extends Events {
             }
         }
 
-        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+        if (!node._data || !node._data.hasOwnProperty(key) || !(node._data[key] instanceof Array))
             return;
 
-        var arr = node._data[key];
+        const arr = node._data[key];
 
         value = obj._doInsert(node, key, value, ind);
 
@@ -704,7 +704,7 @@ class Observer extends Events {
             ind = arr.length - 1;
         }
 
-        var state;
+        let state;
         if (silent)
             state = obj.silence();
 
@@ -720,7 +720,7 @@ class Observer extends Events {
     _doInsert(node, key, value, ind, allowDuplicates) {
         const arr = node._data[key];
 
-        if (typeof(value) === 'object' && ! (value instanceof Observer) && value !== null) {
+        if (typeof value === 'object' && !(value instanceof Observer) && value !== null) {
             if (value instanceof Array) {
                 value = value.slice(0);
             } else {
@@ -754,12 +754,12 @@ class Observer extends Events {
     }
 
     move(path, indOld, indNew, silent, remote) {
-        var keys = Observer._splitPath(path);
-        var key = keys[keys.length - 1];
-        var node = this;
-        var obj = this;
+        const keys = Observer._splitPath(path);
+        const key = keys[keys.length - 1];
+        let node = this;
+        let obj = this;
 
-        for (var i = 0; i < keys.length - 1; i++) {
+        for (let i = 0; i < keys.length - 1; i++) {
             if (node instanceof Array) {
                 node = node[parseInt(keys[i], 10)];
                 if (node instanceof Observer) {
@@ -773,15 +773,15 @@ class Observer extends Events {
             }
         }
 
-        if (! node._data || ! node._data.hasOwnProperty(key) || ! (node._data[key] instanceof Array))
+        if (!node._data || !node._data.hasOwnProperty(key) || !(node._data[key] instanceof Array))
             return;
 
-        var arr = node._data[key];
+        const arr = node._data[key];
 
         if (arr.length < indOld || arr.length < indNew || indOld === indNew)
             return;
 
-        var value = arr[indOld];
+        let value = arr[indOld];
 
         arr.splice(indOld, 1);
 
@@ -790,10 +790,10 @@ class Observer extends Events {
 
         arr.splice(indNew, 0, value);
 
-        if (! (value instanceof Observer))
+        if (!(value instanceof Observer))
             value = obj.json(value);
 
-        var state;
+        let state;
         if (silent)
             state = obj.silence();
 
@@ -807,13 +807,11 @@ class Observer extends Events {
     }
 
     patch(data, removeMIssingKeys) {
-        var key;
-
-        if (typeof(data) !== 'object')
+        if (typeof data !== 'object')
             return;
 
-        for (key in data) {
-            if (typeof(data[key]) === 'object' && ! this._data.hasOwnProperty(key)) {
+        for (const key in data) {
+            if (typeof data[key] === 'object' && !this._data.hasOwnProperty(key)) {
                 this._prepare(this, key, data[key]);
             } else if (this._data[key] !== data[key]) {
                 this.set(key, data[key]);
@@ -821,7 +819,7 @@ class Observer extends Events {
         }
 
         if (removeMIssingKeys) {
-            for (key in this._data) {
+            for (const key in this._data) {
                 if (!data.hasOwnProperty(key)) {
                     this.unset(key);
                 }
@@ -830,24 +828,24 @@ class Observer extends Events {
     }
 
     json(target) {
-        var key, n;
-        var obj = { };
-        var node = target === undefined ? this : target;
-        var len, nlen;
+        let key, n;
+        let obj = { };
+        const node = target === undefined ? this : target;
+        let len, nlen;
 
         if (node instanceof Object && node._keys) {
             len = node._keys.length;
-            for (var i = 0; i < len; i++) {
+            for (let i = 0; i < len; i++) {
                 key = node._keys[i];
-                var value = node._data[key];
-                var type = typeof(value);
+                const value = node._data[key];
+                const type = typeof value;
 
                 if (type === 'object' && (value instanceof Array)) {
                     obj[key] = value.slice(0);
 
                     nlen = obj[key].length;
                     for (n = 0; n < nlen; n++) {
-                        if (typeof(obj[key][n]) === 'object')
+                        if (typeof obj[key][n] === 'object')
                             obj[key][n] = this.json(obj[key][n]);
                     }
                 } else if (type === 'object' && (value instanceof Object)) {
@@ -859,14 +857,14 @@ class Observer extends Events {
         } else {
             if (node === null) {
                 return null;
-            } else if (typeof(node) === 'object' && (node instanceof Array)) {
+            } else if (typeof node === 'object' && (node instanceof Array)) {
                 obj = node.slice(0);
 
                 len = obj.length;
                 for (n = 0; n < len; n++) {
                     obj[n] = this.json(obj[n]);
                 }
-            } else if (typeof(node) === 'object') {
+            } else if (typeof node === 'object') {
                 for (key in node) {
                     if (node.hasOwnProperty(key))
                         obj[key] = node[key];
@@ -878,14 +876,13 @@ class Observer extends Events {
         return obj;
     }
 
-    forEach(fn, target, path) {
-        var node = target || this;
-        path = path || '';
+    forEach(fn, target, path = '') {
+        const node = target || this;
 
-        for (var i = 0; i < node._keys.length; i++) {
-            var key = node._keys[i];
-            var value = node._data[key];
-            var type = (this.schema && this.schema.has(path + key) && this.schema.get(path + key).type.name.toLowerCase()) || typeof(value);
+        for (let i = 0; i < node._keys.length; i++) {
+            const key = node._keys[i];
+            const value = node._data[key];
+            const type = (this.schema && this.schema.has(path + key) && this.schema.get(path + key).type.name.toLowerCase()) || typeof value;
 
             if (type === 'object' && (value instanceof Array)) {
                 fn(path + key, 'array', value, key);

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,12 +1,15 @@
 import Events from './events.js';
 
 /**
- * @class
- * @name Observer
- * @param {any} data - Data
- * @param {any} options - Options
+ * An observer is a class that can be used to observe changes to an object.
+ *
+ * @augments Events
  */
 class Observer extends Events {
+    /**
+     * @param {any} data - Data
+     * @param {any} options - Options
+     */
     constructor(data, options = {}) {
         super();
 
@@ -206,6 +209,14 @@ class Observer extends Events {
         return true;
     }
 
+    /**
+     * @param {string} path - Path to the property in the object.
+     * @param {*} value - Value to set.
+     * @param {boolean} [silent] - If true, the change will not be recorded in history.
+     * @param {boolean} [remote] - TODO.
+     * @param {boolean} [force] - If true, the value will be set even if it is the same as the current value.
+     * @returns {boolean} Returns true if the value was successfully set and false otherwise.
+     */
     set(path, value, silent, remote, force) {
         let i;
         let valueOld;
@@ -463,6 +474,12 @@ class Observer extends Events {
         return true;
     }
 
+    /**
+     * Query whether the object has the specified property.
+     *
+     * @param {string} path - Path to the value.
+     * @returns {boolean} Returns true if the value is present and false otherwise.
+     */
     has(path) {
         const keys = Observer._splitPath(path);
         let node = this;
@@ -480,6 +497,11 @@ class Observer extends Events {
         return node !== undefined;
     }
 
+    /**
+     * @param {string} path - Path to the value.
+     * @param {boolean} [raw] - TODO.
+     * @returns {*} The value at the specified path.
+     */
     get(path, raw) {
         const keys = Observer._splitPath(path);
         let node = this;
@@ -518,6 +540,12 @@ class Observer extends Events {
 
     }
 
+    /**
+     * @param {string} path - Path to the value.
+     * @param {boolean} [silent] - If true, the change will not be recorded in history.
+     * @param {boolean} [remote] - TODO.
+     * @returns {boolean} Returns true if the value was successfully unset and false otherwise.
+     */
     unset(path, silent, remote) {
         let i;
         const keys = Observer._splitPath(path);
@@ -569,6 +597,13 @@ class Observer extends Events {
         return true;
     }
 
+    /**
+     * @param {string} path - Path to the value.
+     * @param {number} ind - Index of the value.
+     * @param {boolean} [silent=false] - If true, the remove event will not be emitted.
+     * @param {boolean} [remote] - TODO.
+     * @returns {boolean} Returns true if the value was successfully removed and false otherwise.
+     */
     remove(path, ind, silent, remote) {
         const keys = Observer._splitPath(path);
         const key = keys[keys.length - 1];
@@ -806,7 +841,7 @@ class Observer extends Events {
         return true;
     }
 
-    patch(data, removeMIssingKeys) {
+    patch(data, removeMissingKeys) {
         if (typeof data !== 'object')
             return;
 
@@ -818,7 +853,7 @@ class Observer extends Events {
             }
         }
 
-        if (removeMIssingKeys) {
+        if (removeMissingKeys) {
             for (const key in this._data) {
                 if (!data.hasOwnProperty(key)) {
                     this.unset(key);
@@ -827,6 +862,10 @@ class Observer extends Events {
         }
     }
 
+    /**
+     * @param {*} [target] - TODO.
+     * @returns {object} The current state of the object tracked by the observer.
+     */
     json(target) {
         let key, n;
         let obj = { };
@@ -906,6 +945,9 @@ class Observer extends Events {
         return this._latestFn ? this._latestFn() : this;
     }
 
+    /**
+     * Destroys the observer instance.
+     */
     destroy() {
         if (this._destroyed) return;
         this._destroyed = true;

--- a/test/observer.test.mjs
+++ b/test/observer.test.mjs
@@ -19,6 +19,11 @@ describe("Observer", () => {
     it('supports constructor with zero arguments', () => {
         const observer = new Observer();
         expect(observer).to.be.an('object');
+
+        observer.set('key', 'hello');
+        expect(observer.get('key')).to.equal('hello');
+
+        observer.destroy();
     });
 
     it('supports querying of properties', () => {
@@ -41,6 +46,8 @@ describe("Observer", () => {
 
         result = observer.has('height');
         expect(result).to.be.false;
+
+        observer.destroy();
     });
 
     it('converts observer data to json', () => {
@@ -61,65 +68,85 @@ describe("Observer", () => {
         expect(json.address).to.be.an('object');
         expect(json.address.city).to.equal('London');
         expect(json.address.street).to.equal('Wall Street');
+
+        observer.destroy();
     });
 
     it('fires wildcard set event when string property is set to a new value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('*:set', () => {
             set = true;
         });
         observer.set('name', 'Peter');
         expect(set).to.be.true;
+
+        observer.destroy();
     });
 
     it('does not fire wildcard set event when string property is set to the same value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('*:set', () => {
             set = true;
         });
         observer.set('name', 'Will');
         expect(set).to.be.false;
+
+        observer.destroy();
     });
 
     it('fires named set event when string property is set to a new value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('name:set', () => {
             set = true;
         });
         observer.set('name', 'Peter');
         expect(set).to.be.true;
+
+        observer.destroy();
     });
 
     it('does not fire named set event when string property is set to the same value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('name:set', () => {
             set = true;
         });
         observer.set('name', 'Will');
         expect(set).to.be.false;
+
+        observer.destroy();
     });
 
     it('fires wildcard set event when 2 part path string property is set to a new value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('*:set', () => {
             set = true;
         });
         observer.set('address.city', 'Los Angeles');
         expect(set).to.be.true;
+
+        observer.destroy();
     });
 
     it('does not fire wildcard set event when 2 part path string property is set to the same value', () => {
         const observer = new Observer(getData());
+
         let set = false;
         observer.on('*:set', () => {
             set = true;
         });
         observer.set('address.city', 'London');
         expect(set).to.be.false;
+
+        observer.destroy();
     });
 });

--- a/test/observer.test.mjs
+++ b/test/observer.test.mjs
@@ -1,0 +1,125 @@
+import Observer from '../src/observer.js';
+
+import { expect } from 'chai';
+
+const getData = () => {
+    return {
+        name: 'Will',
+        age: 46,
+        isMarried: false,
+        address: {
+            city: 'London',
+            street: 'Wall Street'
+        }
+    };
+};
+
+describe("Observer", () => {
+
+    it('supports constructor with zero arguments', () => {
+        const observer = new Observer();
+        expect(observer).to.be.an('object');
+    });
+
+    it('supports querying of properties', () => {
+        const observer = new Observer(getData());
+        expect(observer).to.be.an('object');
+
+        let result;
+        result = observer.has('name');
+        expect(result).to.be.true;
+        result = observer.has('age');
+        expect(result).to.be.true;
+        result = observer.has('isMarried');
+        expect(result).to.be.true;
+        result = observer.has('address');
+        expect(result).to.be.true;
+        result = observer.has('address.city');
+        expect(result).to.be.true;
+        result = observer.has('address.street');
+        expect(result).to.be.true;
+
+        result = observer.has('height');
+        expect(result).to.be.false;
+    });
+
+    it('converts observer data to json', () => {
+        const observer = new Observer(getData());
+        const json = observer.json();
+        expect(json).to.be.an('object');
+
+        expect(json).to.have.property('name');
+        expect(json).to.have.property('age');
+        expect(json).to.have.property('isMarried');
+        expect(json).to.have.property('address');
+        expect(json.address).to.have.property('city');
+        expect(json.address).to.have.property('street');
+
+        expect(json.name).to.equal('Will');
+        expect(json.age).to.equal(46);
+        expect(json.isMarried).to.equal(false);
+        expect(json.address).to.be.an('object');
+        expect(json.address.city).to.equal('London');
+        expect(json.address.street).to.equal('Wall Street');
+    });
+
+    it('fires wildcard set event when string property is set to a new value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('*:set', () => {
+            set = true;
+        });
+        observer.set('name', 'Peter');
+        expect(set).to.be.true;
+    });
+
+    it('does not fire wildcard set event when string property is set to the same value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('*:set', () => {
+            set = true;
+        });
+        observer.set('name', 'Will');
+        expect(set).to.be.false;
+    });
+
+    it('fires named set event when string property is set to a new value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('name:set', () => {
+            set = true;
+        });
+        observer.set('name', 'Peter');
+        expect(set).to.be.true;
+    });
+
+    it('does not fire named set event when string property is set to the same value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('name:set', () => {
+            set = true;
+        });
+        observer.set('name', 'Will');
+        expect(set).to.be.false;
+    });
+
+    it('fires wildcard set event when 2 part path string property is set to a new value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('*:set', () => {
+            set = true;
+        });
+        observer.set('address.city', 'Los Angeles');
+        expect(set).to.be.true;
+    });
+
+    it('does not fire wildcard set event when 2 part path string property is set to the same value', () => {
+        const observer = new Observer(getData());
+        let set = false;
+        observer.on('*:set', () => {
+            set = true;
+        });
+        observer.set('address.city', 'London');
+        expect(set).to.be.false;
+    });
+});


### PR DESCRIPTION
This PR:

* Migrates entire codebase to ES6 (classes, arrow functions, `let` and `const`, default parameters).
* Enables Babel to correctly transform UMD library to ES5 and module to base ES6 feature set.
* Adds some initial unit tests (using [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/)). The tests directly execute the unbuilt source, loading it as modules.
* Adds Typescript definitions.

This PR was tested against the PlayCanvas viewer project.

Fixes #3 