### PR TITLE
TSD - Wrap all classes in the observer namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "lint": "eslint --ext .js index.js src rollup.config.js",
     "publish:observer": "npm run build && npm run tsd && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist",
     "test": "mocha",
-    "tsd": "jsdoc -c conf-tsd.json"
+    "tsd": "jsdoc -c conf-tsd.json && node tsd.js"
   }
 }

--- a/tsd.js
+++ b/tsd.js
@@ -1,0 +1,7 @@
+import fs from 'fs';
+// Add 'export as namespace pc' to the end of the file
+const path = './dist/observer.d.ts';
+let ts = (fs.readFileSync(path, 'utf8')).toString();
+ts = ts.replace(/declare/g, 'export');
+ts += '\n\nexport as namespace observer;\n';
+fs.writeFileSync(path, ts);


### PR DESCRIPTION
Based on how the engine tsd file is created, all classes are now wrapped in the observer namespace.