### PR TITLE
Fix TS declarations for Observer constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/observer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
   "description": "Generic implementation of the observer pattern",
@@ -9,9 +9,9 @@
     "observer"
   ],
   "license": "MIT",
-  "main": "index.js",
-  "module": "index.mjs",
-  "types": "observer.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/observer.d.ts",
   "type": "module",
   "bugs": {
     "url": "https://github.com/playcanvas/playcanvas-observer/issues"
@@ -27,6 +27,14 @@
       "requireConfigFile": false
     }
   },
+  "files": [
+    "dist/index.js",
+    "dist/index.mjs",
+    "dist/observer.d.ts",
+    "LICENSE",
+    "package.json",
+    "README.md"
+  ],
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.0",
@@ -46,7 +54,7 @@
     "build:es6": "rollup -c --environment target:es6",
     "build": "rollup -c --environment target:all",
     "lint": "eslint --ext .js index.js src rollup.config.js",
-    "publish:observer": "npm run build && npm run tsd && cp ./package.json dist && cp ./LICENSE dist && cp README.md dist && npm publish dist",
+    "publish:observer": "npm run build && npm run tsd && npm publish",
     "test": "mocha",
     "tsd": "jsdoc -c conf-tsd.json && node tsd.js"
   }

--- a/src/observer.js
+++ b/src/observer.js
@@ -7,8 +7,8 @@ import Events from './events.js';
  */
 class Observer extends Events {
     /**
-     * @param {any} data - Data
-     * @param {any} options - Options
+     * @param {any} [data] - Data
+     * @param {any} [options] - Options
      */
     constructor(data, options = {}) {
         super();


### PR DESCRIPTION
Update the JSDoc for the Observer constructor to mark both parameters as optional.

Also, slightly modify how the NPM package is published (bringing it more in line with the engine).