### PR TITLE
support async operations in history

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -21,7 +21,7 @@ class History extends Events {
     /**
      * Creates a new History.
      */
-    #executingCounter = 0;
+    _executing = 0;
 
     constructor() {
         super();
@@ -91,10 +91,10 @@ class History extends Events {
         if (this.add(action)) {
             // execute an action - don't allow history actions till it finishes
             try {
-                this.#executing++;
+                this.executing++;
                 await action.redo();
             } finally {
-                this.#executing--;
+                this.executing--;
             }
         }
     }
@@ -120,13 +120,13 @@ class History extends Events {
 
         // execute an undo action - don't allow history actions till it finishes
         try {
-            this.#executing++;
+            this.executing++;
             await undo();
         } catch (ex) {
             console.info('%c(pcui.History#undo)', 'color: #f00');
             console.log(ex.stack);
         } finally {
-            this.#executing--;
+            this.executing--;
         }
     }
 
@@ -149,13 +149,13 @@ class History extends Events {
 
         // execute redo action - don't allow history actions till it finishes
         try {
-            this.#executing++;
+            this.executing++;
             await redo();
         } catch (ex) {
             console.info('%c(pcui.History#redo)', 'color: #f00');
             console.log(ex.stack);
         } finally {
-            this.#executing--;
+            this.executing--;
         }
     }
 
@@ -198,13 +198,13 @@ class History extends Events {
     set canUndo(value) {
         if (this._canUndo === value) return;
         this._canUndo = value;
-        if (!this.#executing) {
+        if (!this.executing) {
             this.emit('canUndo', value);
         }
     }
 
     get canUndo() {
-        return this._canUndo && !this.#executing;
+        return this._canUndo && !this.executing;
     }
 
     /**
@@ -215,13 +215,13 @@ class History extends Events {
     set canRedo(value) {
         if (this._canRedo === value) return;
         this._canRedo = value;
-        if (!this.#executing) {
+        if (!this.executing) {
             this.emit('canRedo', value);
         }
     }
 
     get canRedo() {
-        return this._canRedo && !this.#executing;
+        return this._canRedo && !this.executing;
     }
 
     /**
@@ -229,11 +229,11 @@ class History extends Events {
      *
      * @type {boolean}
      */
-    set #executing(value) {
-        if (this.#executingCounter === value) return;
-        this.#executingCounter = value;
+    set executing(value) {
+        if (this._executing === value) return;
+        this._executing = value;
 
-        if (this.#executingCounter) {
+        if (this._executing) {
             this.emit('canUndo', false);
             this.emit('canRedo', false);
         } else {
@@ -242,8 +242,8 @@ class History extends Events {
         }
     }
 
-    get #executing() {
-        return this.#executingCounter;
+    get executing() {
+        return this._executing;
     }
 }
 

--- a/src/history.js
+++ b/src/history.js
@@ -85,7 +85,7 @@ class History extends Events {
      * @param {HistoryAction.undo} undo - function to execute undo operation
      * @param {HistoryAction.redo} redo - function to execute redo operation
      */
-    async addExecute(action) {
+    async addAndExecute(action) {
         if (this.add(action)) {
             // execute an action - don't allow history actions till it finishes
             try {

--- a/src/history.js
+++ b/src/history.js
@@ -35,6 +35,7 @@ class History extends Events {
      * Adds a new history action
      *
      * @param {HistoryAction} action - The action
+     * @returns {boolean} - Returns `true` if an action is added
      */
     add(action) {
         if (!action.name) {
@@ -84,14 +85,14 @@ class History extends Events {
      * @param {HistoryAction.undo} undo - function to execute undo operation
      * @param {HistoryAction.redo} redo - function to execute redo operation
      */
-     async addExecute(action) {
+    async addExecute(action) {
         if (this.add(action)) {
             // execute an action - don't allow history actions till it finishes
             this.executing = true;
             await action.redo();
             this.executing = false;
         }
-    }    
+    }
 
     /**
      * Undo the last history action
@@ -109,19 +110,17 @@ class History extends Events {
             this.canUndo = false;
         }
 
-        this.canRedo = true;        
+        this.canRedo = true;
 
-        // execute an undo action - don't allow history actions till it finishes        
+        // execute an undo action - don't allow history actions till it finishes
         try {
-            
-            this.executing = true; 
+            this.executing = true;
             await undo();
             this.executing = false;
         } catch (ex) {
             console.info('%c(pcui.History#undo)', 'color: #f00');
             console.log(ex.stack);
-            return;
-        }        
+        }
     }
 
     /**
@@ -140,9 +139,8 @@ class History extends Events {
             this.canRedo = false;
         }
 
-        // execute redo action - don't allow history actions till it finishes        
+        // execute redo action - don't allow history actions till it finishes
         try {
-            
             this.executing = true;
             await redo();
             this.executing = false;
@@ -150,8 +148,7 @@ class History extends Events {
         } catch (ex) {
             console.info('%c(pcui.History#redo)', 'color: #f00');
             console.log(ex.stack);
-            return;
-        }        
+        }
     }
 
     /**
@@ -224,14 +221,13 @@ class History extends Events {
      *
      * @type {boolean}
      */
-     set executing(value) {
+    set executing(value) {
         if (this._executing === value) return;
         this._executing = value;
         if (this._executing) {
             this.emit('canUndo', false);
             this.emit('canRedo', false);
-        }
-        else {
+        } else {
             this.emit('canUndo', this._canUndo);
             this.emit('canRedo', this._canRedo);
         }
@@ -239,7 +235,7 @@ class History extends Events {
 
     get executing() {
         return this._executing;
-    }    
+    }
 }
 
 export default History;


### PR DESCRIPTION
**What's changed:**

Support for long async operations for history module.

_executing counter is added and undo and redo are not allowed to execute while something is running. This is to prevent the situation when submitted action is not yet finished but undo is requested by user. New addAndExecute() method is added - it supports async functions now (could be used with normal functions as well). addAndExecute() executes redo action automatically so developers should make sure that it's consistent. We usually write redo() and executes it before or after adding it to history. 

**Related PR:**

* https://github.com/playcanvas/editor-api/pull/57

**Notes:**

I am still polishing this, but it seems working fine, with proper UI actions (undo/redo buttons enabled/disabled when needed). 

In the current version, we allow next user action to execute even if current is not yet finished (current model), but undo/redo is not allowed if something is still executing. This is the simplest approach. Another method would be adding actions into pending list to execute or blocking actions till the current is executing (bad UX). User actions are usually slower than undo/redo, so the current solution to this is potentially acceptable. 

