### PR TITLE
fix jsdoc for addAndExecute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/observer",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/observer",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/observer",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
   "description": "Generic implementation of the observer pattern",

--- a/src/history.js
+++ b/src/history.js
@@ -84,8 +84,6 @@ class History extends Events {
      * Add a new history action and execute redo after that
      *
      * @param {HistoryAction} action - The action
-     * @param {HistoryAction.undo} undo - function to execute undo operation
-     * @param {HistoryAction.redo} redo - function to execute redo operation
      */
     async addAndExecute(action) {
         if (this.add(action)) {


### PR DESCRIPTION
fix jsdoc for addAndExecute - generated documentation would add 2 additional parameters if we don't