### PR TITLE
Move array equals implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/observer",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/observer",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/observer",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://github.com/playcanvas/playcanvas-observer#readme",
   "description": "Generic implementation of the observer pattern",

--- a/src/observer.js
+++ b/src/observer.js
@@ -24,7 +24,7 @@ const arrayEquals = (a, b) => {
         }
     }
     return true;
-}
+};
 
 /**
  * An observer is a class that can be used to observe changes to an object.

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,5 +1,31 @@
 import Events from './events.js';
 
+// The Observer implementation assumed this array equality function
+// was a member of Array prototype (called 'equals'). This has now
+// been moved here instead.
+const arrayEquals = (a, b) => {
+    if (!a || !b) {
+        return false;
+    }
+
+    const l = a.length;
+
+    if (l !== b.length) {
+        return false;
+    }
+
+    for (let i = 0; i < l; i++) {
+        if (a[i] instanceof Array && b[i] instanceof Array) {
+            if (!arrayEquals(a[i], b[i])) {
+                return false;
+            }
+        } else if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /**
  * An observer is a class that can be used to observe changes to an object.
  *
@@ -307,7 +333,7 @@ class Observer extends Events {
         }
 
         if (typeof value === 'object' && (value instanceof Array)) {
-            if (value.equals(node._data[key]) && !force)
+            if (arrayEquals(value, node._data[key]) && !force)
                 return false;
 
             valueOld = node._data[key];
@@ -533,7 +559,7 @@ class Observer extends Events {
     _equals(a, b) {
         if (a === b) {
             return true;
-        } else if (a instanceof Array && b instanceof Array && a.equals(b)) {
+        } else if (a instanceof Array && b instanceof Array && arrayEquals(a, b)) {
             return true;
         }
         return false;


### PR DESCRIPTION
The observer implementation assumed that Array prototype implemented a function `equals` to compare two arrays. This required all users of observer to monkey patch said function.

This PR moves array equals into observer instead.

Also bump package to v1.4.0.